### PR TITLE
Change ButtonGroup component API

### DIFF
--- a/app/components/polaris/button_group_component.html.erb
+++ b/app/components/polaris/button_group_component.html.erb
@@ -1,7 +1,7 @@
 <%= render Polaris::BaseComponent.new(tag: 'div', **@system_arguments) do %>
-  <% buttons.each do |button| %>
+  <% items.each do |item| %>
     <div class="Polaris-ButtonGroup__Item">
-      <%= button %>
+      <%= item %>
     </div>
   <% end %>
 <% end %>

--- a/app/components/polaris/button_group_component.rb
+++ b/app/components/polaris/button_group_component.rb
@@ -11,7 +11,7 @@ module Polaris
     }
     SPACING_OPTIONS = SPACING_MAPPINGS.keys
 
-    renders_many :buttons, ButtonComponent
+    renders_many :items
 
     def initialize(
       connected_top: false,
@@ -40,7 +40,7 @@ module Polaris
     end
 
     def render?
-      buttons.any?
+      items.any?
     end
   end
 end

--- a/demo/test/components/previews/actions/button_group_component_preview.rb
+++ b/demo/test/components/previews/actions/button_group_component_preview.rb
@@ -13,4 +13,7 @@ class Actions::ButtonGroupComponentPreview < ViewComponent::Preview
 
   def full_width
   end
+
+  def with_text_item
+  end
 end

--- a/demo/test/components/previews/actions/button_group_component_preview/default.html.erb
+++ b/demo/test/components/previews/actions/button_group_component_preview/default.html.erb
@@ -1,4 +1,8 @@
 <%= polaris_button_group do |group| %>
-  <% group.button { "Cancel" } %>
-  <% group.button(primary: true) { "Save" } %>
+  <% group.item do %>
+    <%= polaris_button { "Cancel" } %>
+  <% end %>
+  <% group.item do %>
+    <%= polaris_button(primary: true) { "Save" } %>
+  <% end %>
 <% end %>

--- a/demo/test/components/previews/actions/button_group_component_preview/full_width.html.erb
+++ b/demo/test/components/previews/actions/button_group_component_preview/full_width.html.erb
@@ -1,4 +1,8 @@
 <%= polaris_button_group(full_width: true) do |group| %>
-  <% group.button { "Cancel" } %>
-  <% group.button(primary: true) { "Save" } %>
+  <% group.item do %>
+    <%= polaris_button { "Cancel" } %>
+  <% end %>
+  <% group.item do %>
+    <%= polaris_button(primary: true) { "Save" } %>
+  <% end %>
 <% end %>

--- a/demo/test/components/previews/actions/button_group_component_preview/outline_segmented.html.erb
+++ b/demo/test/components/previews/actions/button_group_component_preview/outline_segmented.html.erb
@@ -1,5 +1,11 @@
 <%= polaris_button_group(segmented: true) do |group| %>
-  <% group.button(outline: true) { "Bold" } %>
-  <% group.button(outline: true) { "Italic" } %>
-  <% group.button(outline: true) { "Underline" } %>
+  <% group.item do %>
+    <%= polaris_button(outline: true) { "Bold" } %>
+  <% end %>
+  <% group.item do %>
+    <%= polaris_button(outline: true) { "Italic" } %>
+  <% end %>
+  <% group.item do %>
+    <%= polaris_button(outline: true) { "Underline" } %>
+  <% end %>
 <% end %>

--- a/demo/test/components/previews/actions/button_group_component_preview/segmented.html.erb
+++ b/demo/test/components/previews/actions/button_group_component_preview/segmented.html.erb
@@ -1,5 +1,11 @@
 <%= polaris_button_group(segmented: true) do |group| %>
-  <% group.button { "Bold" } %>
-  <% group.button { "Italic" } %>
-  <% group.button { "Underline" } %>
+  <% group.item do %>
+    <%= polaris_button { "Bold" } %>
+  <% end %>
+  <% group.item do %>
+    <%= polaris_button { "Italic" } %>
+  <% end %>
+  <% group.item do %>
+    <%= polaris_button { "Underline" } %>
+  <% end %>
 <% end %>

--- a/demo/test/components/previews/actions/button_group_component_preview/with_text_item.html.erb
+++ b/demo/test/components/previews/actions/button_group_component_preview/with_text_item.html.erb
@@ -1,6 +1,9 @@
-<%= polaris_button_group(connected_top: true) do |group| %>
+<%= polaris_button_group do |group| %>
   <% group.item do %>
     <%= polaris_button { "Cancel" } %>
+  <% end %>
+  <% group.item do %>
+    Text Item
   <% end %>
   <% group.item do %>
     <%= polaris_button(primary: true) { "Save" } %>

--- a/test/components/polaris/button_group_component_test.rb
+++ b/test/components/polaris/button_group_component_test.rb
@@ -5,26 +5,22 @@ class ButtonGroupComponentTest < Minitest::Test
 
   def test_default_group
     render_inline(Polaris::ButtonGroupComponent.new) do |group|
-      group.button { "Cancel" }
-      group.button(primary: true) { "Save" }
+      group.item { "Cancel" }
+      group.item { "Save" }
     end
 
     assert_selector ".Polaris-ButtonGroup" do
       assert_selector ".Polaris-ButtonGroup__Item", count: 2
-      assert_selector ".Polaris-ButtonGroup__Item:nth-child(1)" do
-        assert_selector ".Polaris-Button", text: "Cancel"
-      end
-      assert_selector ".Polaris-ButtonGroup__Item:nth-child(2)" do
-        assert_selector ".Polaris-Button.Polaris-Button--primary", text: "Save"
-      end
+      assert_selector ".Polaris-ButtonGroup__Item:nth-child(1)", text: "Cancel"
+      assert_selector ".Polaris-ButtonGroup__Item:nth-child(2)", text: "Save"
     end
   end
 
   def test_segmented_group
     render_inline(Polaris::ButtonGroupComponent.new(segmented: true)) do |group|
-      group.button { "Bold" }
-      group.button { "Italic" }
-      group.button { "Underline" }
+      group.item { "Bold" }
+      group.item { "Italic" }
+      group.item { "Underline" }
     end
 
     assert_selector ".Polaris-ButtonGroup.Polaris-ButtonGroup--segmented[data-buttongroup-segmented='true']" do
@@ -34,8 +30,8 @@ class ButtonGroupComponentTest < Minitest::Test
 
   def test_connected_tops_group
     render_inline(Polaris::ButtonGroupComponent.new(connected_top: true)) do |group|
-      group.button { "Bold" }
-      group.button { "Italic" }
+      group.item { "Bold" }
+      group.item { "Italic" }
     end
 
     assert_selector ".Polaris-ButtonGroup[data-buttongroup-connected-top='true']"
@@ -43,8 +39,8 @@ class ButtonGroupComponentTest < Minitest::Test
 
   def test_full_width_group
     render_inline(Polaris::ButtonGroupComponent.new(full_width: true)) do |group|
-      group.button { "Bold" }
-      group.button { "Italic" }
+      group.item { "Bold" }
+      group.item { "Italic" }
     end
 
     assert_selector ".Polaris-ButtonGroup.Polaris-ButtonGroup--fullWidth[data-buttongroup-full-width='true']"


### PR DESCRIPTION
Old API:
```erb
<%= polaris_button_group do |group| %>
  <% group.button { "Cancel" } %>
  <% group.button(primary: true) { "Save" } %>
<% end %>
```

New API:
```erb
<%= polaris_button_group do |group| %>
  <% group.item do %>
    <%= polaris_button { "Cancel" } %>
  <% end %>
  <% group.item do %>
    <%= polaris_button(primary: true) { "Save" } %>
  <% end %>
<% end %>
```

I have to change it due to ordering issue.