### PR TITLE
Move ApplicationComponent into Polaris module

### DIFF
--- a/app/components/polaris/application_component.rb
+++ b/app/components/polaris/application_component.rb
@@ -1,6 +1,6 @@
 require 'nokogiri'
 
-class ApplicationComponent < ViewComponent::Base
+class Polaris::ApplicationComponent < ViewComponent::Base
   include ActiveModel::Validations
 
   def initialize(data: {}, aria: {}, html_options: {}, **args)

--- a/app/components/polaris/page/component.rb
+++ b/app/components/polaris/page/component.rb
@@ -2,7 +2,7 @@
 
 module Polaris
   module Page
-    class Component < ApplicationComponent
+    class Component < Polaris::ApplicationComponent
       include Polaris::Helpers::ActionHelper
 
       validates :primary_action, type: Polaris::ComplexAction, allow_blank: true

--- a/app/components/polaris/shopify_navigation/component.rb
+++ b/app/components/polaris/shopify_navigation/component.rb
@@ -1,6 +1,6 @@
 module Polaris
   module ShopifyNavigation
-    class Component < ApplicationComponent
+    class Component < Polaris::ApplicationComponent
       def initialize(links:, **args)
         super
 


### PR DESCRIPTION
This will avoid this repo's `Polaris::ApplicationComponent` being ignored if parent app contains its own `ApplicationComponent`

Fixes #46 