### PR TITLE
Create an install generator with helpful output

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ In `Gemfile`, add:
 gem 'polaris_view_components'
 ```
 
+Run install generator:
+```bash
+rails generate polaris_view_components:install
+```
+
 Setup Polaris styles in your layouts `<head>` tag:
 
 ```erb

--- a/lib/generators/polaris_view_components/USAGE
+++ b/lib/generators/polaris_view_components/USAGE
@@ -1,0 +1,5 @@
+Description:
+    Creates or adds import of NPM package to your application + additional installation steps.
+
+Example:
+    rails generate polaris_view_components:install

--- a/lib/generators/polaris_view_components/install_generator.rb
+++ b/lib/generators/polaris_view_components/install_generator.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails/generators/active_record'
+
+module PolarisViewComponents
+  class InstallGenerator < Rails::Generators::Base
+    source_root File.expand_path('templates', __dir__)
+
+    def add_npm_package
+      say "Adding NPM package", :green
+      run "yarn add polaris-view-components"
+    end
+
+    def add_to_stimulus_controller
+      say "Adding import to to Stimulus controller", :green
+      dir_path = "app/javascript/controllers"
+      empty_directory('app/javascript')
+      empty_directory(dir_path)
+
+      file_path = "#{dir_path}/index.js"
+
+      unless File.exist?(file_path)
+        copy_file 'stimulus_index.js', file_path
+      end
+
+      append_to_file file_path do
+        "import { registerPolarisControllers } from 'polaris-view-components'\nregisterPolarisControllers(application)"
+      end
+    end
+
+    def show_readme
+      readme 'README'
+    end
+  end
+end

--- a/lib/generators/polaris_view_components/templates/README
+++ b/lib/generators/polaris_view_components/templates/README
@@ -1,0 +1,14 @@
+===============================================================================
+
+Some manual setup is still required:
+
+  1. Setup Polaris styles in your layouts <head> tag:
+
+       <link rel="stylesheet" href="https://unpkg.com/@shopify/polaris@6.6.0/dist/styles.css" />
+       <%= stylesheet_link_tag 'polaris_view_components' %>
+
+  2. Define Polaris style on your <body> tag:
+
+       <body style="<%= polaris_body_styles %>">
+
+===============================================================================

--- a/lib/generators/polaris_view_components/templates/stimulus_index.js
+++ b/lib/generators/polaris_view_components/templates/stimulus_index.js
@@ -1,0 +1,7 @@
+import { Application } from 'stimulus'
+import { definitionsFromContext } from 'stimulus/webpack-helpers'
+
+const application = Application.start(document.documentElement)
+const context = require.context('.', true, /_controller\.js$/)
+application.load(definitionsFromContext(context))
+


### PR DESCRIPTION
Cut down on installation steps by adding them to a rails generator. It is an attempt to close out #99 but went the generator route instead.

`rails generate polaris_view_components:install`

<img width="774" alt="Screen Shot 2021-09-08 at 11 16 41 AM" src="https://user-images.githubusercontent.com/2224702/132537437-1ff25de5-58bb-4e4f-91c8-ddb743c62dd2.png">
