### PR TITLE
Dispatches 'change' event when the field type is a number

### DIFF
--- a/app/assets/javascripts/polaris_view_components.js
+++ b/app/assets/javascripts/polaris_view_components.js
@@ -1624,6 +1624,7 @@ class TextField extends Controller {
     const decimalPlaces = Math.max(dpl(numericValue), dpl(this.stepValue));
     const newValue = Math.min(Number(this.maxValue), Math.max(numericValue + steps * this.stepValue, Number(this.minValue)));
     this.value = String(newValue.toFixed(decimalPlaces));
+    this.inputTarget.dispatchEvent(new Event("change"));
   }
 }
 

--- a/app/assets/javascripts/polaris_view_components/text_field_controller.js
+++ b/app/assets/javascripts/polaris_view_components/text_field_controller.js
@@ -107,5 +107,6 @@ export default class extends Controller {
     )
 
     this.value = String(newValue.toFixed(decimalPlaces))
+    this.inputTarget.dispatchEvent(new Event('change'));
   }
 }


### PR DESCRIPTION
Hi folks!

First wanted to say thanks for your great work on this project. I'm using these components in my current project and I have a use case where I have a form that auto-saves when the user enters data via 'keyup' or 'change' events. In the case of a number text field, such as:

```
<%= polaris_text_field(
  name: :quantity,
  value: 1.34,
  type: :number,
) %>

```

When the user increases or decreases the number by clicking on the up or down arrows, there is no change event triggered so my form doesn't know to save.  

This PR dispatches 'change' event when the field type is a number and the value is changed by increasing or decreasing the value via the up and down arrows on the field allowing me to capture the event and handle it accordingly. 

