### PR TITLE
Ensure backwards compatibility with Rails 6.0 and lower for error_summary

### DIFF
--- a/app/helpers/polaris/form_builder.rb
+++ b/app/helpers/polaris/form_builder.rb
@@ -17,8 +17,8 @@ module Polaris
         status: :critical
       ) do
         render(Polaris::ListComponent.new) do |list|
-          object.errors.each do |error|
-            list.item { error.full_message.html_safe }
+          object.errors.full_messages.each do |error|
+            list.item { error.html_safe }
           end
         end
       end

--- a/test/helpers/polaris/form_builder_test.rb
+++ b/test/helpers/polaris/form_builder_test.rb
@@ -6,6 +6,8 @@ class Polaris::ViewHelperTest < ActionView::TestCase
   class Product
     include ActiveModel::Model
     attr_accessor :title, :status, :accept, :access
+
+    validates :title, presence: true
   end
 
   setup do
@@ -14,14 +16,16 @@ class Polaris::ViewHelperTest < ActionView::TestCase
   end
 
   test "#errors_summary" do
+    @product.validate
     @product.errors.add(:base, "Base Error")
 
     @rendered_component = @builder.errors_summary
 
     assert_selector ".Polaris-Banner--statusCritical" do
-      assert_text "1 error with this product"
+      assert_text "2 errors with this product"
       assert_selector ".Polaris-Banner__Content" do
         assert_selector "li", text: "Base Error"
+        assert_selector "li", text: "Title can't be blank"
       end
     end
   end


### PR DESCRIPTION
First off thanks for this repo! The way this project is structured is really nice and tidy!

I was trying to rewrite my shopify app using this gem but found the `error_summary` was giving me an error (undefined method `full_message' for :name:Symbol).

When looking at the test code nothing seems to be wrong, but apparently `ActiveModel::Errors` [changed](https://code.lulalala.com/2020/0531-1013.html) a bit with 6.1. We're still running 6.0.

These changes should ensure older versions of Rails keep working!