### PR TITLE
Add support for remote suggestions in Autocomplete

### DIFF
--- a/app/assets/javascripts/polaris_view_components.js
+++ b/app/assets/javascripts/polaris_view_components.js
@@ -28,13 +28,10 @@ class Autocomplete extends Controller {
     this.inputTarget.removeEventListener("input", this.onInputChange);
   }
   toggle() {
-    if (this.visibleOptions.length > 0) {
-      this.hideEmptyState();
-      this.popoverController.show();
-    } else if (this.value.length > 0 && this.hasEmptyStateTarget) {
-      this.showEmptyState();
+    if (this.isRemote && this.visibleOptions.length == 0 && this.value.length == 0) {
+      this.fetchResults();
     } else {
-      this.popoverController.forceHide();
+      this.handleResults();
     }
   }
   select(event) {
@@ -68,6 +65,16 @@ class Autocomplete extends Controller {
   get visibleOptions() {
     return this.optionTargets.filter((option => !option.classList.contains("Polaris--hidden")));
   }
+  handleResults() {
+    if (this.visibleOptions.length > 0) {
+      this.hideEmptyState();
+      this.popoverController.show();
+    } else if (this.value.length > 0 && this.hasEmptyStateTarget) {
+      this.showEmptyState();
+    } else {
+      this.popoverController.forceHide();
+    }
+  }
   filterOptions() {
     if (this.value === "") {
       this.optionTargets.forEach((option => {
@@ -83,7 +90,7 @@ class Autocomplete extends Controller {
         }
       }));
     }
-    this.toggle();
+    this.handleResults();
   }
   async fetchResults() {
     const response = await get(this.urlValue, {
@@ -94,7 +101,7 @@ class Autocomplete extends Controller {
     if (response.ok) {
       const results = await response.html;
       this.resultsTarget.innerHTML = results;
-      this.toggle();
+      this.handleResults();
     }
   }
   showEmptyState() {

--- a/app/assets/javascripts/polaris_view_components/autocomplete_controller.js
+++ b/app/assets/javascripts/polaris_view_components/autocomplete_controller.js
@@ -17,13 +17,10 @@ export default class extends Controller {
   // Actions
 
   toggle() {
-    if (this.visibleOptions.length > 0) {
-      this.hideEmptyState()
-      this.popoverController.show()
-    } else if (this.value.length > 0 && this.hasEmptyStateTarget) {
-      this.showEmptyState()
+    if (this.isRemote && this.visibleOptions.length == 0 && this.value.length == 0) {
+      this.fetchResults()
     } else {
-      this.popoverController.forceHide()
+      this.handleResults()
     }
   }
 
@@ -66,6 +63,17 @@ export default class extends Controller {
     })
   }
 
+  handleResults() {
+    if (this.visibleOptions.length > 0) {
+      this.hideEmptyState()
+      this.popoverController.show()
+    } else if (this.value.length > 0 && this.hasEmptyStateTarget) {
+      this.showEmptyState()
+    } else {
+      this.popoverController.forceHide()
+    }
+  }
+
   filterOptions() {
     if (this.value === '') {
       this.optionTargets.forEach(option => {
@@ -81,7 +89,7 @@ export default class extends Controller {
         }
       })
     }
-    this.toggle()
+    this.handleResults()
   }
 
   async fetchResults() {
@@ -91,7 +99,7 @@ export default class extends Controller {
     if (response.ok) {
       const results = await response.html
       this.resultsTarget.innerHTML = results
-      this.toggle()
+      this.handleResults()
     }
   }
 

--- a/demo/app/views/suggestions/index.html.erb
+++ b/demo/app/views/suggestions/index.html.erb
@@ -1,11 +1,8 @@
-<% if @query.blank? %>
-  <%= polaris_autocomplete_section(title: "Suggested tags") do |section| %>
-    <% @options.each do |option| %>
-      <%= section.option(label: option[:label], value: option[:value]) %>
-    <% end %>
-  <% end %>
-<% else %>
+<%= polaris_autocomplete_section(
+  title: @query.blank? && "Suggested tags",
+  multiple: true
+) do |section| %>
   <% @options.each do |option| %>
-    <%= polaris_autocomplete_option(label: option[:label], value: option[:value]) %>
+    <%= section.option(label: option[:label], value: option[:value]) %>
   <% end %>
 <% end %>

--- a/demo/test/components/previews/forms/autocomplete_component_preview/remote.html.erb
+++ b/demo/test/components/previews/forms/autocomplete_component_preview/remote.html.erb
@@ -1,5 +1,5 @@
 <%= polaris_autocomplete(multiple: true, url: suggestions_path) do |autocomplete| %>
-  <% autocomplete.text_field(label: "Tags", placeholder: "Search") do |c| %>
+  <% autocomplete.text_field(label: "Tags with local suggestions", placeholder: "Search") do |c| %>
     <% c.prefix do %>
       <%= polaris_icon(name: "SearchMinor") %>
     <% end %>
@@ -11,5 +11,15 @@
     <% section.option(label: "Vinyl", value: "vinyl") %>
     <% section.option(label: "Vintage", value: "vintage") %>
     <% section.option(label: "Refurbished", value: "refurbished") %>
+  <% end %>
+<% end %>
+
+<br>
+
+<%= polaris_autocomplete(multiple: true, url: suggestions_path) do |autocomplete| %>
+  <% autocomplete.text_field(label: "Tags with remote suggestions", placeholder: "Search") do |c| %>
+    <% c.prefix do %>
+      <%= polaris_icon(name: "SearchMinor") %>
+    <% end %>
   <% end %>
 <% end %>


### PR DESCRIPTION
Allows pulling blank state suggestions from server in remote Autocomplete. In the example below suggestions will be pulled on click on an empty text field:
```erb
<%= polaris_autocomplete(multiple: true, url: suggestions_path) do |autocomplete| %>
  <% autocomplete.text_field(label: "Tags", placeholder: "Search") do |c| %>
    <% c.prefix do %>
      <%= polaris_icon(name: "SearchMinor") %>
    <% end %>
  <% end %>
<% end %>
```