### PR TITLE
Remove .field_with_errors wrapper

### DIFF
--- a/lib/polaris/view_components/engine.rb
+++ b/lib/polaris/view_components/engine.rb
@@ -14,6 +14,11 @@ module Polaris
         #{root}/app/components
         #{root}/app/helpers
       ]
+      
+      # Remove default wrapping .field_with_errors for proper Shopify form validations
+      config.to_prepare do
+        ActionView::Base.field_error_proc = ->(html_tag, _instance) { html_tag }
+      end
 
       initializer "polaris_view_components.assets" do |app|
         if app.config.respond_to?(:assets)

--- a/lib/polaris/view_components/engine.rb
+++ b/lib/polaris/view_components/engine.rb
@@ -17,7 +17,7 @@ module Polaris
       
       # Remove default wrapping .field_with_errors for proper Shopify form validations
       config.to_prepare do
-        ActionView::Base.field_error_proc = ->(html_tag, _instance) { html_tag }
+        ActionView::Base.field_error_proc = ->(html_tag, _instance) { html_tag.html_safe }
       end
 
       initializer "polaris_view_components.assets" do |app|


### PR DESCRIPTION
Hi!

I noticed some form validation errors were not displayed nicely. Upon inspection I found that by default Rails wraps fields with errors inside a div (.field_with_errors) and this breaks some styling for Polaris.

**Before overwriting proc:**
![Screenshot 2022-01-24 at 11 54 40](https://user-images.githubusercontent.com/64841/150777951-540a084a-ab83-4c65-a0fd-063692dcc38e.png)
![Screenshot 2022-01-24 at 11 55 33](https://user-images.githubusercontent.com/64841/150777955-afeed57d-2866-441b-8f52-835a19fffe4c.png)

**After overwriting proc:**
![Screenshot 2022-01-24 at 11 56 10](https://user-images.githubusercontent.com/64841/150777959-26c1e2a3-7222-4405-b00d-aa3022c0cf7a.png)

Overwriting the `field_error_proc` in this way is less then ideal, but assuming users of this gem are not using any other gems that are responsible for the user interface of the Shopify admin it should be safe to implement it like this.

Alternatively it could be possible to add a step to the install generator adding the `field_error_proc` to the app itself.

But seeing as there is an active discussion on refactoring the `field_error_proc` it could be nice to remove the proc as soon as custom form builders support the option of setting a `field_error_proc`

See: https://github.com/rails/rails/issues/39522
And: https://discuss.rubyonrails.org/t/feature-allow-for-override-of-field-error-proc-in-the-formbuilder-could-prepare-pr-if-the-approach-is-reasonable/79843

Let me know what you think is the best approach!