### PR TITLE
Implement shortcut actions for resource item

### DIFF
--- a/app/components/polaris/resource_item_component.html.erb
+++ b/app/components/polaris/resource_item_component.html.erb
@@ -7,7 +7,8 @@
           tabindex="0"
           href="<%= @url %>"
           data-polaris-unstyled="true"
-          data-polaris-resource-item-target="link"></a>
+          data-polaris-resource-item-target="link"
+        ></a>
       <% end %>
 
       <%= render(Polaris::BaseComponent.new(**container_arguments)) do %>
@@ -28,9 +29,20 @@
             <% end %>
           <% end %>
         <% end %>
+
         <div class="Polaris-ResourceItem__Content">
           <%= content %>
         </div>
+
+        <% if @shortcut_actions.present? %>
+          <div class="Polaris-ResourceItem__Actions">
+            <%= polaris_button_group(segmented: true) do |group| %>
+              <% @shortcut_actions.each do |action| %>
+                <%= group.button(**action) { action[:content] } %>
+              <% end %>
+            <% end %>
+          </div>
+        <% end %>
       <% end %>
     <% end %>
   </div>

--- a/app/components/polaris/resource_item_component.rb
+++ b/app/components/polaris/resource_item_component.rb
@@ -32,6 +32,8 @@ module Polaris
       cursor: CURSOR_DEFAULT,
       selectable: false,
       offset: false,
+      shortcut_actions: [],
+      persist_actions: false,
       wrapper_arguments: {},
       container_arguments: {},
       **system_arguments
@@ -41,6 +43,14 @@ module Polaris
       @cursor = fetch_or_fallback(CURSOR_OPTIONS, cursor, CURSOR_DEFAULT)
       @selectable = selectable
       @offset = offset
+      @shortcut_actions = shortcut_actions.map do |action|
+        if persist_actions
+          action.merge(plain: true)
+        else
+          action.merge(size: :slim)
+        end
+      end
+      @persist_actions = persist_actions
       @wrapper_arguments = wrapper_arguments
       @container_arguments = container_arguments
       @system_arguments = system_arguments
@@ -79,7 +89,8 @@ module Polaris
         args[:classes] = class_names(
           args[:classes],
           "Polaris-ResourceItem",
-          "Polaris-ResourceItem--selectable": @selectable
+          "Polaris-ResourceItem--selectable": @selectable,
+          "Polaris-ResourceItem--persistActions": @persist_actions
         )
         prepend_option(args, :style, "cursor: #{@cursor};")
         prepend_option(args[:data], :action, "click->polaris-resource-item#open")

--- a/demo/test/components/previews/lists_and_tables/resource_item_component_preview.rb
+++ b/demo/test/components/previews/lists_and_tables/resource_item_component_preview.rb
@@ -16,4 +16,11 @@ class ListsAndTables::ResourceItemComponentPreview < ViewComponent::Preview
 
   def with_vertical_alignment
   end
+
+  # Shortcut actions present popular actions from the resource’s details page for easy access. A shortcut action should be available on every item in the list.
+  def with_shortcut_actions
+  end
+
+  def with_shortcut_actions_persisted
+  end
 end

--- a/demo/test/components/previews/lists_and_tables/resource_item_component_preview/with_shortcut_actions.html.erb
+++ b/demo/test/components/previews/lists_and_tables/resource_item_component_preview/with_shortcut_actions.html.erb
@@ -1,0 +1,12 @@
+<% shortcut_actions = [
+  { content: 'View customer', url: '#' },
+  { content: 'Print invoice', url: '#' },
+] %>
+
+<%= polaris_card(sectioned: false) do %>
+  <%= polaris_resource_list do %>
+    <%= polaris_resource_item(shortcut_actions: shortcut_actions) do %>
+      <p>Content</p>
+    <% end %>
+  <% end %>
+<% end %>

--- a/demo/test/components/previews/lists_and_tables/resource_item_component_preview/with_shortcut_actions_persisted.html.erb
+++ b/demo/test/components/previews/lists_and_tables/resource_item_component_preview/with_shortcut_actions_persisted.html.erb
@@ -1,0 +1,12 @@
+<% shortcut_actions = [
+  { content: 'View customer', url: '#' },
+  { content: 'Print invoice', url: '#' },
+] %>
+
+<%= polaris_card(sectioned: false) do %>
+  <%= polaris_resource_list do %>
+    <%= polaris_resource_item(shortcut_actions: shortcut_actions, persist_actions: true) do %>
+      <p>Content</p>
+    <% end %>
+  <% end %>
+<% end %>


### PR DESCRIPTION
Adds the `shortcut_actions` and `persist_actions` options from the [ResourceItem](https://polaris.shopify.com/components/lists-and-tables/resource-item)