### PR TITLE
Improve Filters popover position and alignment

### DIFF
--- a/app/components/polaris/filters_component.rb
+++ b/app/components/polaris/filters_component.rb
@@ -74,7 +74,9 @@ module Polaris
       def popover_arguments
         {
           sectioned: @sectioned,
-          style: ("width: #{@width}" if @width.present?)
+          style: ("width: #{@width}" if @width.present?),
+          position: :below,
+          alignment: :left
         }
       end
 


### PR DESCRIPTION
Filters popover will now unfold down-left, similar to Polaris React:
<img width="324" alt="CleanShot 2022-04-21 at 19 57 31@2x" src="https://user-images.githubusercontent.com/839922/164512376-d932c9f1-2d79-4884-b035-34fc9c0f29d2.png">

