### PR TITLE
Add support for selected in Resource Item component

### DIFF
--- a/app/components/polaris/resource_item_component.rb
+++ b/app/components/polaris/resource_item_component.rb
@@ -31,6 +31,7 @@ module Polaris
       vertical_alignment: ALIGNMENT_DEFAULT,
       cursor: CURSOR_DEFAULT,
       selectable: false,
+      selected: false,
       offset: false,
       wrapper_arguments: {},
       container_arguments: {},
@@ -40,6 +41,7 @@ module Polaris
       @vertical_alignment = vertical_alignment
       @cursor = fetch_or_fallback(CURSOR_OPTIONS, cursor, CURSOR_DEFAULT)
       @selectable = selectable
+      @selected = selected
       @offset = offset
       @wrapper_arguments = wrapper_arguments
       @container_arguments = container_arguments
@@ -79,7 +81,8 @@ module Polaris
         args[:classes] = class_names(
           args[:classes],
           "Polaris-ResourceItem",
-          "Polaris-ResourceItem--selectable": @selectable
+          "Polaris-ResourceItem--selectable": @selectable,
+          "Polaris-ResourceItem--selected": @selected
         )
         prepend_option(args, :style, "cursor: #{@cursor};")
         prepend_option(args[:data], :action, "click->polaris-resource-item#open")

--- a/demo/test/components/previews/lists_and_tables/resource_item_component_preview.rb
+++ b/demo/test/components/previews/lists_and_tables/resource_item_component_preview.rb
@@ -16,4 +16,7 @@ class ListsAndTables::ResourceItemComponentPreview < ViewComponent::Preview
 
   def with_vertical_alignment
   end
+
+  def with_selected
+  end
 end

--- a/demo/test/components/previews/lists_and_tables/resource_item_component_preview/with_selected.html.erb
+++ b/demo/test/components/previews/lists_and_tables/resource_item_component_preview/with_selected.html.erb
@@ -1,0 +1,10 @@
+<%= polaris_card(sectioned: false) do %>
+  <%= polaris_resource_list do %>
+    <%= polaris_resource_item do %>
+      <p>Content</p>
+    <% end %>
+    <%= polaris_resource_item(selected: true) do %>
+      <p>Selected content</p>
+    <% end %>
+  <% end %>
+<% end %>


### PR DESCRIPTION
## Purpose of this PR
- Currently, there isn't a way to add a `selected` flag to `polaris_resource_item` to show which item is selected
- The workaround I am using right now is shown below:

```erb
<%= polaris_resource_item(classes: "Polaris-ResourceItem--selected") do %>
  ...
<% end %>
```
- After this PR is merge, this can be done with a simple `selected` argument:

```erb
<%= polaris_resource_item(selected: true) do %>
  ...
<% end %>
```

## Changes

- Add `selected` flag to the `Polaris::ResourceItemComponent` with the `Polaris-ResourceItem--selected`
  - The `selectable` flag does not need to be passed for the `selected` flag to be set to `true`
- Add `with_selected` component preview

## Screenshots

### Lookbook

![image](https://user-images.githubusercontent.com/13711901/167273577-3b9db3d9-6323-4995-bb17-bbd7ee2b3170.png)

### In the wild

![image](https://user-images.githubusercontent.com/13711901/167273598-5c2bb175-a6cb-4735-80c1-5dea0085fcec.png)

