### PR TITLE
Fix file assignment for drag&drop in Dropzone

### DIFF
--- a/app/assets/javascripts/polaris_view_components.js
+++ b/app/assets/javascripts/polaris_view_components.js
@@ -441,6 +441,7 @@ class Dropzone extends Controller {
     this.dragging = false;
   }
   onDrop(e) {
+    this.inputTarget.files = e.dataTransfer.files;
     this.stopEvent(e);
     if (this.disabled) return;
     this.dragging = false;

--- a/app/assets/javascripts/polaris_view_components.js
+++ b/app/assets/javascripts/polaris_view_components.js
@@ -361,11 +361,11 @@ class Dropzone extends Controller {
     size: String
   };
   files=[];
-  acceptedFiles=[];
   rejectedFiles=[];
   _dragging=false;
   dragTargets=[];
   previewRendered=false;
+  _acceptedFiles=[];
   _size="large";
   connect() {
     document.body.addEventListener("click", this.onExternalTriggerClick);
@@ -441,7 +441,6 @@ class Dropzone extends Controller {
     this.dragging = false;
   }
   onDrop(e) {
-    this.inputTarget.files = e.dataTransfer.files;
     this.stopEvent(e);
     if (this.disabled) return;
     this.dragging = false;
@@ -686,6 +685,15 @@ class Dropzone extends Controller {
     const sizeClassesToRemove = Object.values(this.sizeClassesSchema);
     sizeClassesToRemove.forEach((className => this.element.classList.remove(className)));
     this.element.classList.add(this.getSizeClass(val));
+  }
+  get acceptedFiles() {
+    return this._acceptedFiles;
+  }
+  set acceptedFiles(val) {
+    this._acceptedFiles = val;
+    const list = new DataTransfer;
+    val.forEach((file => list.items.add(file)));
+    this.inputTarget.files = list.files;
   }
 }
 

--- a/app/assets/javascripts/polaris_view_components/dropzone_controller.js
+++ b/app/assets/javascripts/polaris_view_components/dropzone_controller.js
@@ -139,6 +139,7 @@ export default class extends Controller {
   }
 
   onDrop (e) {
+    this.inputTarget.files = e.dataTransfer.files
     this.stopEvent(e)
     if (this.disabled) return
 

--- a/app/assets/javascripts/polaris_view_components/dropzone_controller.js
+++ b/app/assets/javascripts/polaris_view_components/dropzone_controller.js
@@ -34,11 +34,12 @@ export default class extends Controller {
   }
 
   files = []
-  acceptedFiles = []
   rejectedFiles = []
   _dragging = false
   dragTargets = []
   previewRendered = false
+
+  _acceptedFiles = []
   _size = 'large'
 
   connect () {
@@ -139,7 +140,6 @@ export default class extends Controller {
   }
 
   onDrop (e) {
-    this.inputTarget.files = e.dataTransfer.files
     this.stopEvent(e)
     if (this.disabled) return
 
@@ -452,6 +452,20 @@ export default class extends Controller {
     sizeClassesToRemove.forEach(className => this.element.classList.remove(className))
 
     this.element.classList.add(this.getSizeClass(val))
+  }
+
+  get acceptedFiles () {
+    return this._acceptedFiles
+  }
+
+  set acceptedFiles (val) {
+    this._acceptedFiles = val
+
+    const list = new DataTransfer()
+
+    val.forEach(file => list.items.add(file))
+
+    this.inputTarget.files = list.files
   }
 }
 

--- a/test/system/dropzone_component_test.rb
+++ b/test/system/dropzone_component_test.rb
@@ -18,6 +18,19 @@ class DropzoneComponentSystemTest < ApplicationSystemTestCase
     end
   end
 
+  def test_submiting_file
+    with_preview("rails/form_builder_component/dropzone")
+
+    within first("form") do
+      find(".Polaris-DropZone").drop(fixture_file("file.txt"))
+      assert_selector ".Polaris-DropZone__Preview > .Polaris-Stack > .Polaris-Stack__Item", count: 1
+
+      click_on "Submit"
+    end
+
+    assert_text "File: file.txt"
+  end
+
   def test_image_upload
     with_preview("forms/dropzone_component/with_image_upload")
 


### PR DESCRIPTION
Closes #237

I added the assignment of dropped files to `inputTarget`. But this way all dropped files will be attached even if they will be later rejected in `onChange` handler. @dan-gamble maybe you know a better solution?