### PR TITLE
Autocomplete: Select value if it's not multiple autocomplete

### DIFF
--- a/app/assets/javascripts/polaris_view_components/popover_controller.js
+++ b/app/assets/javascripts/polaris_view_components/popover_controller.js
@@ -1,9 +1,9 @@
-import { Controller } from "@hotwired/stimulus"
-import { createPopper } from "@popperjs/core/dist/esm"
+import { Controller } from '@hotwired/stimulus'
+import { createPopper } from '@popperjs/core/dist/esm'
 
 export default class extends Controller {
-  static targets = ["activator", "popover"]
-  static classes = ["open", "closed"]
+  static targets = ['activator', 'popover']
+  static classes = ['open', 'closed']
   static values = {
     placement: String,
     active: Boolean
@@ -16,20 +16,24 @@ export default class extends Controller {
         {
           name: 'offset',
           options: {
-            offset: [0, 5],
-          },
+            offset: [0, 5]
+          }
         },
         {
           name: 'flip',
           options: {
             allowedAutoPlacements: ['top-start', 'bottom-start', 'top-end', 'bottom-end']
-          },
+          }
         }
       ]
     })
     if (this.activeValue) {
       this.show()
     }
+  }
+
+  get isActive() {
+    return this.popoverTarget.classList.contains(this.openClass)
   }
 
   toggle() {

--- a/app/components/polaris/autocomplete/option_component.rb
+++ b/app/components/polaris/autocomplete/option_component.rb
@@ -20,7 +20,7 @@ module Polaris
         args[:wrapper_arguments][:data][:label] = @label
 
         args[:data] ||= {}
-        prepend_option(args[:data], :action, "polaris-autocomplete#select")
+        prepend_option(args[:data], :action, "polaris-autocomplete#onSelect")
       end
     end
 

--- a/app/components/polaris/autocomplete_component.rb
+++ b/app/components/polaris/autocomplete_component.rb
@@ -2,14 +2,17 @@ module Polaris
   class AutocompleteComponent < Component
     renders_one :text_field, ->(**system_arguments) do
       system_arguments[:data] ||= {}
-      prepend_option(system_arguments[:data], :action, %w[
-        click->polaris-autocomplete#toggle
-        click@window->polaris-popover#hide
-      ])
+      prepend_option(system_arguments[:data], :action, "click@window->polaris-popover#hide")
 
       system_arguments[:input_options] ||= {}
-      system_arguments[:input_options][:data] ||= {}
-      system_arguments[:input_options][:data][:polaris_autocomplete_target] = "input"
+      system_arguments[:input_options][:data] = {
+        polaris_autocomplete_target: "input",
+        action: %w[
+          focus->polaris-autocomplete#onFocus
+          blur->polaris-autocomplete#onBlur
+          input->polaris-autocomplete#onInput
+        ]
+      }.deep_merge(system_arguments[:input_options][:data] || {})
 
       TextFieldComponent.new(**system_arguments)
     end
@@ -38,9 +41,8 @@ module Polaris
         opts[:tag] = "div"
         opts[:data] ||= {}
         opts[:data][:controller] = "polaris-autocomplete"
-        if @url.present?
-          opts[:data][:polaris_autocomplete_url_value] = @url
-        end
+        opts[:data][:polaris_autocomplete_url_value] = @url if @url.present?
+        opts[:data][:polaris_autocomplete_multiple_value] = @multiple if @multiple.present?
         opts[:data][:polaris_autocomplete_selected_value] = @selected
       end
     end

--- a/test/system/autocomplete_component_test.rb
+++ b/test/system/autocomplete_component_test.rb
@@ -4,28 +4,46 @@ class AutocompleteComponentSystemTest < ApplicationSystemTestCase
   def test_basic_autocomplete
     with_preview("forms/autocomplete_component/basic")
 
-    # Open autocomplete
-    find(".Polaris-TextField__Input").click
+    open_autocomplete
     assert_selector ".Polaris-OptionList-Option", text: "Rustic"
     assert_selector ".Polaris-OptionList-Option", text: "Vintage"
 
-    # Enter query
-    find(".Polaris-TextField__Input").set "Vint"
+    type_text "Vint"
     assert_no_selector ".Polaris-OptionList-Option", text: "Rustic"
     assert_selector ".Polaris-OptionList-Option", text: "Vintage"
+  end
+
+  def test_selecting_non_multiple
+    with_preview("forms/autocomplete_component/basic")
+
+    open_autocomplete
+    type_text "Vint"
+    find(".Polaris-OptionList-Option", text: "Vintage").click
+
+    assert_field "Tags", with: "Vintage"
+  end
+
+  def test_selecting_multiple
+    with_preview("forms/autocomplete_component/multiselect")
+
+    open_autocomplete
+    find(".Polaris-OptionList-Option", text: "Vintage").click
+    find(".Polaris-OptionList-Option", text: "Rustic").click
+
+    # assert_field 'Tags', with: 'Vintage,Rustic'
+    assert_selector ".Polaris-OptionList-Checkbox__Input:checked[value=vintage]"
+    assert_selector ".Polaris-OptionList-Checkbox__Input:checked[value=rustic]"
   end
 
   def test_preselected_autocomplete
     with_preview("forms/autocomplete_component/preselected")
 
-    # Open autocomplete
-    find(".Polaris-TextField__Input").click
+    open_autocomplete
     assert_no_selector ".Polaris-OptionList-Checkbox__Input:checked[value=rustic]"
     assert_selector ".Polaris-OptionList-Checkbox__Input:checked[value=antique]"
     assert_selector ".Polaris-OptionList-Checkbox__Input:checked[value=vintage]"
 
-    # Enter query
-    find(".Polaris-TextField__Input").set "Vin"
+    type_text "Vin"
     assert_no_selector ".Polaris-OptionList-Checkbox__Input:checked[value=vinyl]"
     assert_selector ".Polaris-OptionList-Checkbox__Input:checked[value=vintage]"
   end
@@ -38,12 +56,11 @@ class AutocompleteComponentSystemTest < ApplicationSystemTestCase
       assert_selector ".Polaris-Label", text: "Tags with local suggestions"
 
       # Check default suggestions
-      find(".Polaris-TextField__Input").click
+      open_autocomplete
       assert_selector ".Polaris-OptionList-Option", text: "Rustic"
       assert_selector ".Polaris-OptionList-Option", text: "Vintage"
 
-      # Enter query
-      find(".Polaris-TextField__Input").set "Vint"
+      type_text "Vint"
       assert_no_selector ".Polaris-OptionList-Option", text: "Rustic"
       assert_selector ".Polaris-OptionList-Option", text: "Vintage"
     end
@@ -53,12 +70,11 @@ class AutocompleteComponentSystemTest < ApplicationSystemTestCase
       assert_selector ".Polaris-Label", text: "Tags with remote suggestions"
 
       # Check default suggestions
-      find(".Polaris-TextField__Input").click
+      open_autocomplete
       assert_selector ".Polaris-OptionList-Option", text: "Rustic"
       assert_selector ".Polaris-OptionList-Option", text: "Vintage"
 
-      # Enter query
-      find(".Polaris-TextField__Input").set "Vint"
+      type_text "Vint"
       assert_no_selector ".Polaris-OptionList-Option", text: "Rustic"
       assert_selector ".Polaris-OptionList-Option", text: "Vintage"
     end
@@ -67,22 +83,26 @@ class AutocompleteComponentSystemTest < ApplicationSystemTestCase
   def test_empty_state
     with_preview("forms/autocomplete_component/empty_state")
 
-    find(".Polaris-TextField__Input").click
-    find(".Polaris-TextField__Input").set "Unknown"
+    open_autocomplete
+    type_text "Unknown"
     assert_selector ".Polaris-Autocomplete__EmptyState", text: "Could not find any results"
   end
 
   def test_event_handler
     with_preview("forms/autocomplete_component/event_handler")
 
-    # Open autocomplete
-    find(".Polaris-TextField__Input").click
+    open_autocomplete
     assert_selector ".Polaris-OptionList-Option", text: "Rustic"
 
     # Select Vinyl
     accept_alert "Selected vinyl" do
       find(".Polaris-OptionList-Option", text: "Vinyl").click
     end
-    assert_selector ".Polaris-OptionList-Option--select", text: "Vinyl"
   end
+
+  private
+
+  def autocomplete_input_field = find(".Polaris-TextField__Input")
+  def open_autocomplete = autocomplete_input_field.click
+  def type_text(text) = autocomplete_input_field.set(text)
 end


### PR DESCRIPTION
Fixes #242

This _could_ be merged, but it's also a work-in-progress.

The issue (and difference from React Polaris) is that here we use label text as a value instead of the option value.

Maybe this could be the v1/MVP, and a better solution could be to have another hidden input field where we'll store the actual value. The shown text input field could be w/o `name` attribute. I think that would prevent it from submitting its value on form submit. (We only want the value of the hidden input field to be submitted).
