### PR TITLE
Deploy updated demo to Heroku after release

### DIFF
--- a/script/release
+++ b/script/release
@@ -18,5 +18,17 @@ git tag v$VERSION
 git push --tags
 gem build polaris_view_components.gemspec
 gem push "polaris_view_components-$VERSION.gem"
+rm polaris_view_components.gemspec
 
 echo "Need to publish NPM package too?"
+
+while true; do
+  read -p "Deploy new version to Heroku? [Yn] " yn
+  case $yn in
+    [Yy]* )
+      git push heroku main
+      break;;
+    [Nn]* ) break;;
+    * ) echo "Please answer yes or no.";;
+  esac
+done


### PR DESCRIPTION
Previously we used Heroku auto-deploys from main branches. This led to issues with unreleased features being deployed to demo site. With this change, we'll deploy the demo site only after releasing a new version.

Closes #248 