### PR TITLE
Allow keeping file previews after direct file upload

### DIFF
--- a/app/assets/javascripts/polaris_view_components.js
+++ b/app/assets/javascripts/polaris_view_components.js
@@ -394,7 +394,8 @@ class Dropzone extends Controller {
     dropOnPage: Boolean,
     focused: Boolean,
     renderPreview: Boolean,
-    size: String
+    size: String,
+    removePreviewsAfterUpload: Boolean
   };
   files=[];
   rejectedFiles=[];
@@ -494,7 +495,7 @@ class Dropzone extends Controller {
   };
   onDirectUploadsEnd=() => {
     this.enable();
-    this.clearFiles();
+    this.clearFiles(this.removePreviewsAfterUploadValue);
     if (this.acceptedFiles.length === 0) return;
     if (this.hasLoaderTarget) this.loaderTarget.classList.remove("Polaris--hidden");
   };
@@ -650,12 +651,12 @@ class Dropzone extends Controller {
     }
     return clone;
   }
-  clearFiles() {
+  clearFiles(removePreview = true) {
     if (!this.previewRendered) return;
     this.acceptedFiles = [];
     this.files = [];
     this.rejectedFiles = [];
-    this.removePreview();
+    if (removePreview) this.removePreview();
   }
   removePreview() {
     if (!this.hasPreviewTarget) return;

--- a/app/assets/javascripts/polaris_view_components/dropzone_controller.js
+++ b/app/assets/javascripts/polaris_view_components/dropzone_controller.js
@@ -30,7 +30,8 @@ export default class extends Controller {
     dropOnPage: Boolean,
     focused: Boolean,
     renderPreview: Boolean,
-    size: String
+    size: String,
+    removePreviewsAfterUpload: Boolean
   }
 
   files = []
@@ -164,7 +165,7 @@ export default class extends Controller {
 
   onDirectUploadsEnd = () => {
     this.enable()
-    this.clearFiles()
+    this.clearFiles(this.removePreviewsAfterUploadValue)
 
     if (this.acceptedFiles.length === 0) return
 
@@ -358,14 +359,15 @@ export default class extends Controller {
     return clone
   }
 
-  clearFiles () {
+  clearFiles (removePreview = true) {
     if (!this.previewRendered) return
 
     this.acceptedFiles = []
     this.files = []
     this.rejectedFiles = []
 
-    this.removePreview()
+    if (removePreview)
+      this.removePreview()
   }
 
   removePreview () {

--- a/app/components/polaris/dropzone_component.rb
+++ b/app/components/polaris/dropzone_component.rb
@@ -37,6 +37,7 @@ module Polaris
       label_action: nil,
       disabled: false,
       error: false,
+      remove_previews_after_upload: true,
       file_upload_button: nil,
       file_upload_help: "or drop files to upload",
       file_upload_arguments: {},
@@ -62,6 +63,7 @@ module Polaris
       @label_action = label_action
       @disabled = disabled
       @error = error
+      @remove_previews_after_upload = remove_previews_after_upload
       @file_upload_button = file_upload_button
       @file_upload_button ||= "Add #{multiple ? "files" : "file"}"
       @file_upload_help = file_upload_help
@@ -82,7 +84,8 @@ module Polaris
           polaris_dropzone_focused_value: "false",
           polaris_dropzone_drop_on_page_value: @drop_on_page,
           polaris_dropzone_render_preview_value: @preview,
-          polaris_dropzone_size_value: @size
+          polaris_dropzone_size_value: @size,
+          polaris_dropzone_remove_previews_after_upload_value: @remove_previews_after_upload
         }
       }.deep_merge(@system_arguments).tap do |opts|
         prepend_option(opts[:data], :controller, "polaris-dropzone")


### PR DESCRIPTION
Added option `remove_previews_after_upload` to `Dropzone`. It's set to `true` by default to keep the old behaviour. But now we can set it to `false` to keep preview after direct upload.

Example:
```erb
<%= form.polaris_dropzone(:file, direct_upload: true, remove_previews_after_upload: false) %>
```