### PR TITLE
Allow configurable popover arguments for shortcut actions

### DIFF
--- a/app/components/polaris/resource_item/shortcut_actions_component.html.erb
+++ b/app/components/polaris/resource_item/shortcut_actions_component.html.erb
@@ -8,7 +8,7 @@
 
 <% if @persist_actions %>
   <%= render(Polaris::BaseComponent.new(**disclosure_arguments)) do %>
-    <%= render(Polaris::PopoverComponent.new(alignment: :right)) do |popover| %>
+    <%= render(Polaris::PopoverComponent.new(**popover_arguments)) do |popover| %>
       <% popover.button(disclosure: :horizontal_dots, plain: true) %>
 
       <%= render(Polaris::ActionListComponent.new) do |action_list| %>

--- a/app/components/polaris/resource_item/shortcut_actions_component.rb
+++ b/app/components/polaris/resource_item/shortcut_actions_component.rb
@@ -10,11 +10,13 @@ class Polaris::ResourceItem::ShortcutActionsComponent < Polaris::Component
     persist_actions: false,
     wrapper_arguments: {},
     disclosure_arguments: {},
+    popover_arguments: {},
     **system_arguments
   )
     @persist_actions = persist_actions
     @wrapper_arguments = wrapper_arguments
     @disclosure_arguments = disclosure_arguments
+    @popover_arguments = popover_arguments
     @system_arguments = system_arguments
   end
 
@@ -36,6 +38,13 @@ class Polaris::ResourceItem::ShortcutActionsComponent < Polaris::Component
         "Polaris-ResourceItem__Disclosure"
       )
     end
+  end
+
+  def popover_arguments
+    {
+      alignment: :right,
+      position: :below
+    }.deep_merge(@popover_arguments)
   end
 
   def system_arguments


### PR DESCRIPTION
Hi!

I ran into an issue with the shortcut actions and the popover. The popover would only open to the top. This seems to have to do something with the amount of space there is left on the bottom of the page.

Setting position to below fixes this issue. Also added `popover_arguments` to the shortcut actions component for more control.