### PR TITLE
Fix DropZone Preview on Rails 6.0.x

### DIFF
--- a/app/components/polaris/dropzone_component.html.erb
+++ b/app/components/polaris/dropzone_component.html.erb
@@ -87,12 +87,12 @@
     <template data-polaris-dropzone-target="previewTemplate">
       <%= tag.div(
         data: { polaris_dropzone_target: "preview" },
-        class: [
-          "Polaris-DropZone__Preview",
+        class: {
+          "Polaris-DropZone__Preview": true,
           "Polaris-DropZone__Preview--singleFile": !@multiple,
           "Polaris-DropZone__Preview--sizeMedium": @size == :medium,
           "Polaris-DropZone__Preview--sizeSmall": @size == :small,
-        ]
+        }
       ) do %>
         <% if @size.in?(%i[small]) %>
           <span class="target"></span>

--- a/test/components/polaris/dropzone_component_test.rb
+++ b/test/components/polaris/dropzone_component_test.rb
@@ -15,6 +15,14 @@ class ActionListComponentTest < Minitest::Test
     end
   end
 
+  def test_dropzone_preview_template
+    rendered = render_inline(Polaris::DropzoneComponent.new(name: :file_input))
+    template = rendered.at_css("template[data-polaris-dropzone-target=previewTemplate] > *").to_html
+    template_page = Capybara::Node::Simple.new(template)
+
+    assert_selector template_page, ".Polaris-DropZone__Preview", visible: :all
+  end
+
   def test_dropzone_with_label
     render_inline(Polaris::DropzoneComponent.new(label: "Dropzone Label", label_hidden: false))
 


### PR DESCRIPTION
### Why make this change?
On Rails 6.0, ActionView::Helpers::TagHelper handles `tag.div(class: ["class-1", "class-2": true])` differently than Rails 7. This results in an invalid class string rendered into the DropZone preview template.

The class in question:
<img width="605" alt="Screen Shot 2022-08-27 at 16 15 47" src="https://user-images.githubusercontent.com/381219/187051155-821353ad-06e1-4937-94ba-91491b7bedca.png">

Before preview:
<img width="407" alt="Screen Shot 2022-08-27 at 16 13 27" src="https://user-images.githubusercontent.com/381219/187051234-80fd71c8-6b87-4417-bf6f-976849c7b40f.png">


After preview:
<img width="394" alt="Screen Shot 2022-08-27 at 16 19 32" src="https://user-images.githubusercontent.com/381219/187051227-519adf11-00d3-4d55-9c63-758a510ce718.png">

### What changed in this pull request?
This pull request uses a hash, rather than an array with a nested hash, to calculate the CSS classes for the DropZone Preview.

### Tasks

- [x] Code is tested
- [x] Root cause is described
- [x] Screenshots are attached