### PR TITLE
Allow overriding checkbox state in form builder

### DIFF
--- a/app/components/polaris/base_checkbox.rb
+++ b/app/components/polaris/base_checkbox.rb
@@ -23,6 +23,7 @@ module Polaris
     def system_arguments
       @system_arguments.tap do |opts|
         opts[:disabled] = true if @disabled
+        opts[:checked] = true if @checked
         opts[:aria] ||= {}
         opts[:aria][:checked] = @checked
         if indeterminate?

--- a/demo/app/previews/form_builder_component_preview/check_box.html.erb
+++ b/demo/app/previews/form_builder_component_preview/check_box.html.erb
@@ -3,4 +3,9 @@
     label: "Basic checkbox",
     help_text: "Customers must review their order details before purchasing.",
   ) %>
+  <%= form.polaris_check_box(:accept,
+    label: "Checked checkbox",
+    help_text: 'Checkbox with overriden "checked" option.',
+    checked: true
+  ) %>
 <% end %>

--- a/test/helpers/polaris/form_builder_test.rb
+++ b/test/helpers/polaris/form_builder_test.rb
@@ -83,6 +83,14 @@ class Polaris::ViewHelperTest < ActionView::TestCase
     end
   end
 
+  test "#polaris_check_box checked" do
+    @rendered_content = @builder.polaris_check_box(:accept, label: "Checkbox Label", checked: true)
+
+    assert_selector ".Polaris-Checkbox" do
+      assert_selector %(input[name="product[accept]"][type="checkbox"][checked="checked"])
+    end
+  end
+
   test "#polaris_radio_button" do
     @rendered_content = @builder.polaris_radio_button(:access, value: :allow, label: "Radio Label")
 


### PR DESCRIPTION
```erb
<%= form_with(model: product, builder: Polaris::FormBuilder) do |form| %>
  <%= form.polaris_check_box(:accept,
    label: "Checked checkbox",
    help_text: 'Checkbox with overriden "checked" option.',
    checked: true
  ) %>
<% end %>
```