### PR TITLE
Allow passing form attribute to checkboxes

### DIFF
--- a/app/components/polaris/base_checkbox.rb
+++ b/app/components/polaris/base_checkbox.rb
@@ -31,6 +31,7 @@ module Polaris
           @system_arguments[:aria][:checked] = "mixed"
         end
         opts[:class] = opts.delete(:classes)
+        @system_arguments[:form] = @form if @form.present? && !@attribute.present?
       end
     end
 

--- a/app/components/polaris/base_checkbox.rb
+++ b/app/components/polaris/base_checkbox.rb
@@ -31,7 +31,7 @@ module Polaris
           @system_arguments[:aria][:checked] = "mixed"
         end
         opts[:class] = opts.delete(:classes)
-        @system_arguments[:form] = @form if @form.present? && !@attribute.present?
+        opts[:form] = @form if @form.present? && @attribute.blank?
       end
     end
 

--- a/test/components/polaris/checkbox_component_test.rb
+++ b/test/components/polaris/checkbox_component_test.rb
@@ -39,5 +39,12 @@ class CheckboxComponentTest < Minitest::Test
     render_inline(Polaris::CheckboxComponent.new(label: "Label", checked: :indeterminate))
 
     assert_selector "input.Polaris-Checkbox__Input--indeterminate[type=checkbox][indeterminate]"
+    assert_no_selector "[form]"
+  end
+
+  def test_remote_form
+    render_inline(Polaris::CheckboxComponent.new(form: :form_with_an_id))
+
+    assert_selector "[form=form_with_an_id]"
   end
 end


### PR DESCRIPTION
Normally I would submit to a remote form like this. I can't do it in polaris_checkbox_tag. 
```
    <%= check_box_tag "order_ids[]",
                      order.id,
                      current_shop.setting.auto_select_orders,
                      {
                        multiple: true,
                        form: :bulk_actions_form,
                        data: { checkbox_select_all_target: "child", action: "change->checkbox-select-all#toggleParent"}
                      } %>
```

With my changes now I can define and successfully pass a `form` attribute to a polaris_check_box:

```
    <%= polaris_check_box(name: 'order_ids[]',
                          value: order.id,
                          checked: true,
                          input_options: { 
                                           form: :bulk_actions_form,
                                           multiple: true,
                                           data: {} }) %>
```