### PR TITLE
Fix version requirement for @rails/request.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "peerDependencies": {
     "@hotwired/stimulus": "^3.0.0",
-    "@rails/request.js": "^0.0.6"
+    "@rails/request.js": ">= 0.0.6"
   },
   "scripts": {
     "build": "rollup --config rollup.config.js",


### PR DESCRIPTION
Carret (^) doesn't work properly with 0 major version in NPM 🤷‍♂️

Closes #278