### PR TITLE
Fix Polaris Links Fail to Render with `nil` Content

### DIFF
--- a/app/components/polaris/link_component.rb
+++ b/app/components/polaris/link_component.rb
@@ -30,7 +30,7 @@ module Polaris
 
     def call
       render(Polaris::BaseComponent.new(**@system_arguments)) do
-        content.strip.html_safe
+        content&.strip&.html_safe
       end
     end
   end


### PR DESCRIPTION
Hi, thanks for the lovely gem.

## Description

Most of the Polaris components have no worries to render contents that are possible to have `nil` objects like

```ruby
polaris_heading { product.sku } #=> could be nil, <div class="class="Polaris-Card__Header">....
# etc ...
```

However, using `polaris_link` seems to fail on the content that could be `nil` ones

```ruby
polaris_link(...) { product.sku } #=> undefined method 'strip' for nil:NilClass
```

Probably we could make those behaviours more consistent?
