### PR TITLE
Feature: add `readonly` attribute support for text field

### DIFF
--- a/app/components/polaris/text_field_component.rb
+++ b/app/components/polaris/text_field_component.rb
@@ -48,6 +48,7 @@ module Polaris
       label_hidden: false,
       label_action: nil,
       disabled: false,
+      readonly: false,
       required: false,
       help_text: nil,
       error: false,
@@ -78,6 +79,7 @@ module Polaris
       @label_hidden = label_hidden
       @label_action = label_action
       @disabled = disabled
+      @readonly = readonly
       @required = required
       @help_text = help_text
       @error = error
@@ -112,6 +114,7 @@ module Polaris
           opts[:classes],
           "Polaris-TextField",
           "Polaris-TextField--disabled": @disabled,
+          "Polaris-TextField--readOnly": @readonly,
           "Polaris-TextField--error": @error,
           "Polaris-TextField--hasValue": @value.present?,
           "Polaris-TextField--multiline": @multiline
@@ -128,6 +131,7 @@ module Polaris
       default_options = {
         value: @value,
         disabled: @disabled,
+        readonly: @readonly,
         required: @required,
         placeholder: @placeholder,
         maxlength: @maxlength,

--- a/demo/app/previews/text_field_component_preview.rb
+++ b/demo/app/previews/text_field_component_preview.rb
@@ -41,6 +41,9 @@ class TextFieldComponentPreview < ViewComponent::Preview
   def disabled
   end
 
+  def readonly
+  end
+
   def with_character_count
   end
 

--- a/demo/app/previews/text_field_component_preview/readonly.html.erb
+++ b/demo/app/previews/text_field_component_preview/readonly.html.erb
@@ -1,0 +1,6 @@
+<%= polaris_text_field(
+  name: :store_name,
+  value: 'Jaded Pixel',
+  label: 'Store name',
+  readonly: true,
+) %>

--- a/test/components/polaris/text_field_component_test.rb
+++ b/test/components/polaris/text_field_component_test.rb
@@ -204,6 +204,18 @@ class TextFieldComponentTest < Minitest::Test
     end
   end
 
+  def test_readonly
+    render_inline(Polaris::TextFieldComponent.new(
+      name: :input_name,
+      label: "Label",
+      readonly: true
+    ))
+
+    assert_selector ".Polaris-TextField.Polaris-TextField--readOnly" do
+      assert_selector "input[readonly=readonly]"
+    end
+  end
+
   def test_character_count
     render_inline(Polaris::TextFieldComponent.new(
       name: :input_name,


### PR DESCRIPTION
resolves https://github.com/baoagency/polaris_view_components/issues/302