### PR TITLE
Add support for grouped and time zone options

### DIFF
--- a/app/components/polaris/select_component.html.erb
+++ b/app/components/polaris/select_component.html.erb
@@ -3,14 +3,14 @@
     <% if @form.present? && @attribute.present? %>
       <%= @form.select(
         @attribute,
-        options_for_select(@options, selected: @selected, disabled: @disabled_options),
+        build_options_for_select,
         @select_options,
         @input_options,
       ) %>
     <% else %>
       <%= select_tag(
         @name,
-        options_for_select(@options, selected: @selected, disabled: @disabled_options),
+        build_options_for_select,
         @input_options,
       ) %>
     <% end %>

--- a/demo/app/models/product.rb
+++ b/demo/app/models/product.rb
@@ -1,5 +1,5 @@
 class Product
   include ActiveModel::Model
 
-  attr_accessor :title, :status
+  attr_accessor :title, :status, :country
 end

--- a/demo/app/previews/form_builder_component_preview/select.html.erb
+++ b/demo/app/previews/form_builder_component_preview/select.html.erb
@@ -26,5 +26,15 @@
         select_options: { include_blank: true },
       ) %>
     <% end %>
+
+    <% form_layout.with_item do %>
+      <%= form.polaris_select(:country,
+        options: {
+          'North America' => [['United States','US'], 'Canada'],
+          'Europe' => ['Denmark','Germany','France']
+        },
+        grouped: true
+      ) %>
+    <% end %>
   <% end %>
 <% end %>

--- a/demo/app/previews/select_component_preview.rb
+++ b/demo/app/previews/select_component_preview.rb
@@ -2,6 +2,12 @@ class SelectComponentPreview < ViewComponent::Preview
   def default
   end
 
+  def grouped
+  end
+
+  def time_zone
+  end
+
   def inline_label
   end
 

--- a/demo/app/previews/select_component_preview/grouped.html.erb
+++ b/demo/app/previews/select_component_preview/grouped.html.erb
@@ -1,0 +1,40 @@
+<%= polaris_select(
+  name: :country,
+  label: "Country",
+  grouped: true,
+  options: {
+    'North America' => [['United States','US'], 'Canada'],
+    'Europe' => ['Denmark','Germany','France']
+  },
+  selected: "Canada"
+) %>
+
+<br>
+
+<%= polaris_select(
+  name: :country,
+  label: "Country",
+  grouped: true,
+  options: [
+    ['North America',
+     [['United States','US'],'Canada']],
+    ['Europe',
+     ['Denmark','Germany','France']]
+  ],
+  selected: "Canada",
+  prompt: "Select country"
+) %>
+
+<br>
+
+<%= polaris_select(
+  name: :country,
+  label: "Country",
+  grouped: true,
+  options: [
+    [['United States','US'], 'Canada'],
+    ['Denmark','Germany','France']
+  ],
+  prompt: "Select country",
+  divider: "---------"
+) %>

--- a/demo/app/previews/select_component_preview/time_zone.html.erb
+++ b/demo/app/previews/select_component_preview/time_zone.html.erb
@@ -1,0 +1,6 @@
+<%= polaris_select(
+  name: :time_zone,
+  time_zone: true,
+  label: "Time zone",
+  selected: ActiveSupport::TimeZone.new('Eastern Time (US & Canada)').name
+) %>

--- a/test/components/polaris/select_component_test.rb
+++ b/test/components/polaris/select_component_test.rb
@@ -138,4 +138,210 @@ class SelectComponentTest < Minitest::Test
       assert_selector ".Polaris-InlineError", text: "Inline Error"
     end
   end
+
+  def test_grouped_select_with_hash
+    render_inline(Polaris::SelectComponent.new(
+      name: :input_name,
+      label: "Input Label",
+      grouped: true,
+      options: {
+        "North America" => [["United States", "US"], "Canada"],
+        "Europe" => ["Denmark", "Germany", "France"]
+      },
+      selected: "US"
+    ))
+
+    assert_selector "div" do
+      assert_selector ".Polaris-Labelled__LabelWrapper > .Polaris-Label" do
+        assert_selector "label.Polaris-Label__Text[for=input_name]", text: "Input Label"
+      end
+      assert_selector ".Polaris-Select[data-controller='polaris-select']" do
+        assert_selector "select.Polaris-Select__Input[name=input_name][data-action='polaris-select#update']" do
+          assert_selector "optgroup", count: 2
+          assert_selector "optgroup[label='North America']" do
+            assert_selector "option[value='US']:nth-child(1)", text: "United States"
+            assert_selector "option[value='Canada']:nth-child(2)", text: "Canada"
+          end
+          assert_selector "optgroup[label='Europe']" do
+            assert_selector "option[value='Denmark']:nth-child(1)", text: "Denmark"
+            assert_selector "option[value='Germany']:nth-child(2)", text: "Germany"
+            assert_selector "option[value='France']:nth-child(3)", text: "France"
+          end
+        end
+        assert_selector ".Polaris-Select__Content" do
+          assert_selector ".Polaris-Select__SelectedOption[data-polaris-select-target='selectedOption']", text: "United States"
+          assert_selector ".Polaris-Select__Icon > .Polaris-Icon"
+          assert_selector ".Polaris-Select__Backdrop"
+        end
+      end
+    end
+  end
+
+  def test_grouped_select_with_array
+    render_inline(Polaris::SelectComponent.new(
+      name: :input_name,
+      label: "Input Label",
+      grouped: true,
+      options: [
+        ["North America",
+          [["United States", "US"], "Canada"]],
+        ["Europe",
+          ["Denmark", "Germany", "France"]]
+      ],
+      selected: "France"
+    ))
+
+    assert_selector "div" do
+      assert_selector ".Polaris-Labelled__LabelWrapper > .Polaris-Label" do
+        assert_selector "label.Polaris-Label__Text[for=input_name]", text: "Input Label"
+      end
+      assert_selector ".Polaris-Select[data-controller='polaris-select']" do
+        assert_selector "select.Polaris-Select__Input[name=input_name][data-action='polaris-select#update']" do
+          assert_selector "optgroup", count: 2
+          assert_selector "optgroup[label='North America']" do
+            assert_selector "option[value='US']:nth-child(1)", text: "United States"
+            assert_selector "option[value='Canada']:nth-child(2)", text: "Canada"
+          end
+          assert_selector "optgroup[label='Europe']" do
+            assert_selector "option[value='Denmark']:nth-child(1)", text: "Denmark"
+            assert_selector "option[value='Germany']:nth-child(2)", text: "Germany"
+            assert_selector "option[value='France']:nth-child(3)", text: "France"
+          end
+        end
+        assert_selector ".Polaris-Select__Content" do
+          assert_selector ".Polaris-Select__SelectedOption[data-polaris-select-target='selectedOption']", text: "France"
+          assert_selector ".Polaris-Select__Icon > .Polaris-Icon"
+          assert_selector ".Polaris-Select__Backdrop"
+        end
+      end
+    end
+  end
+
+  def test_grouped_select_with_prompt
+    render_inline(Polaris::SelectComponent.new(
+      name: :input_name,
+      label: "Input Label",
+      grouped: true,
+      options: [
+        ["North America",
+          [["United States", "US"], "Canada"]],
+        ["Europe",
+          ["Denmark", "Germany", "France"]]
+      ],
+      selected: "France",
+      prompt: "Select country"
+    ))
+
+    assert_selector "div" do
+      assert_selector ".Polaris-Labelled__LabelWrapper > .Polaris-Label" do
+        assert_selector "label.Polaris-Label__Text[for=input_name]", text: "Input Label"
+      end
+      assert_selector ".Polaris-Select[data-controller='polaris-select']" do
+        assert_selector "select.Polaris-Select__Input[name=input_name][data-action='polaris-select#update']" do
+          assert_selector "option", text: "Select country"
+          assert_selector "optgroup", count: 2
+          assert_selector "optgroup[label='North America']" do
+            assert_selector "option[value='US']:nth-child(1)", text: "United States"
+            assert_selector "option[value='Canada']:nth-child(2)", text: "Canada"
+          end
+          assert_selector "optgroup[label='Europe']" do
+            assert_selector "option[value='Denmark']:nth-child(1)", text: "Denmark"
+            assert_selector "option[value='Germany']:nth-child(2)", text: "Germany"
+            assert_selector "option[value='France']:nth-child(3)", text: "France"
+          end
+        end
+        assert_selector ".Polaris-Select__Content" do
+          assert_selector ".Polaris-Select__SelectedOption[data-polaris-select-target='selectedOption']", text: "France"
+          assert_selector ".Polaris-Select__Icon > .Polaris-Icon"
+          assert_selector ".Polaris-Select__Backdrop"
+        end
+      end
+    end
+  end
+
+  def test_grouped_select_with_divider_with_selected
+    render_inline(Polaris::SelectComponent.new(
+      name: :input_name,
+      label: "Input Label",
+      grouped: true,
+      options: [
+        [["United States", "US"], "Canada"],
+        ["Denmark", "Germany", "France"]
+      ],
+      divider: "------------",
+      selected: "Canada"
+    ))
+
+    assert_selector "div" do
+      assert_selector ".Polaris-Labelled__LabelWrapper > .Polaris-Label" do
+        assert_selector "label.Polaris-Label__Text[for=input_name]", text: "Input Label"
+      end
+      assert_selector ".Polaris-Select[data-controller='polaris-select']" do
+        assert_selector "select.Polaris-Select__Input[name=input_name][data-action='polaris-select#update']" do
+          assert_selector "optgroup[label='------------']", count: 2
+        end
+        assert_selector ".Polaris-Select__Content" do
+          assert_selector ".Polaris-Select__SelectedOption[data-polaris-select-target='selectedOption']", text: "Canada"
+          assert_selector ".Polaris-Select__Icon > .Polaris-Icon"
+          assert_selector ".Polaris-Select__Backdrop"
+        end
+      end
+    end
+  end
+
+  def test_grouped_select_with_divider_without_selected
+    render_inline(Polaris::SelectComponent.new(
+      name: :input_name,
+      label: "Input Label",
+      grouped: true,
+      options: [
+        ["North America",
+          [["United States", "US"], "Canada"]],
+        ["Europe",
+          ["Denmark", "Germany", "France"]]
+      ],
+      divider: "------------"
+    ))
+
+    assert_selector "div" do
+      assert_selector ".Polaris-Labelled__LabelWrapper > .Polaris-Label" do
+        assert_selector "label.Polaris-Label__Text[for=input_name]", text: "Input Label"
+      end
+      assert_selector ".Polaris-Select[data-controller='polaris-select']" do
+        assert_selector "select.Polaris-Select__Input[name=input_name][data-action='polaris-select#update']" do
+          assert_selector "optgroup[label='------------']", count: 2
+        end
+        assert_selector ".Polaris-Select__Content" do
+          assert_selector ".Polaris-Select__SelectedOption[data-polaris-select-target='selectedOption']", text: ""
+          assert_selector ".Polaris-Select__Icon > .Polaris-Icon"
+          assert_selector ".Polaris-Select__Backdrop"
+        end
+      end
+    end
+  end
+
+  def test_select_with_time_zone
+    render_inline(Polaris::SelectComponent.new(
+      name: :input_name,
+      label: "Time zone",
+      time_zone: true,
+      selected: "Eastern Time (US & Canada)"
+    ))
+
+    assert_selector "div" do
+      assert_selector ".Polaris-Labelled__LabelWrapper > .Polaris-Label" do
+        assert_selector "label.Polaris-Label__Text[for=input_name]", text: "Time zone"
+      end
+      assert_selector ".Polaris-Select[data-controller='polaris-select']" do
+        assert_selector "select.Polaris-Select__Input[name=input_name][data-action='polaris-select#update']" do
+          assert_selector "option", count: 151
+        end
+        assert_selector ".Polaris-Select__Content" do
+          assert_selector ".Polaris-Select__SelectedOption[data-polaris-select-target='selectedOption']", text: "(GMT-05:00) Eastern Time (US & Canada)"
+          assert_selector ".Polaris-Select__Icon > .Polaris-Icon"
+          assert_selector ".Polaris-Select__Backdrop"
+        end
+      end
+    end
+  end
 end

--- a/test/system/select_component_test.rb
+++ b/test/system/select_component_test.rb
@@ -15,4 +15,34 @@ class SelectComponentSystemTest < ApplicationSystemTestCase
       assert_selector ".Polaris-Select__Content", text: "Today"
     end
   end
+
+  def test_grouped_select
+    with_preview("select_component/grouped")
+
+    within first(".Polaris-Select") do
+      # Default option
+      assert_selector ".Polaris-Select__Content", text: "Canada"
+
+      # Select new option
+      within "select#country", visible: false do
+        find("option[value='US']").click
+      end
+      assert_selector ".Polaris-Select__Content", text: "United States"
+    end
+  end
+
+  def test_time_zone_select
+    with_preview("select_component/time_zone")
+
+    within first(".Polaris-Select") do
+      # Default option
+      assert_selector ".Polaris-Select__Content", text: "Canada"
+
+      # Select new option
+      within "select#time_zone", visible: false do
+        find("option[value='International Date Line West']").click
+      end
+      assert_selector ".Polaris-Select__Content", text: "(GMT-12:00) International Date Line West"
+    end
+  end
 end


### PR DESCRIPTION
Also added `prompt` and `divider` parameters for grouped options

According to https://github.com/baoagency/polaris_view_components/issues/176