### PR TITLE
add pagination_label to page_component

### DIFF
--- a/app/components/polaris/page_component.html.erb
+++ b/app/components/polaris/page_component.html.erb
@@ -108,10 +108,15 @@
                 <% if has_pagination? %>
                   <div class="Polaris-Page-Header__PaginationWrapper">
                     <nav aria-label="Pagination">
-                      <%= polaris_button_group(segmented: true) do |group| %>
+                      <%= polaris_button_group(segmented: @pagination_label.blank?) do |group| %>
                         <% group.with_item do %>
                           <%= polaris_button(url: @prev_url, outline: true, disabled: @prev_url.blank?) do |button| %>
                             <% button.with_icon(name: "ChevronLeftMinor") %>
+                          <% end %>
+                        <% end %>
+                        <% if @pagination_label.present? %>
+                          <% group.with_item do %>
+                            <div aria-live="polite"><%= @pagination_label %></div>
                           <% end %>
                         <% end %>
                         <% group.with_item do %>

--- a/app/components/polaris/page_component.rb
+++ b/app/components/polaris/page_component.rb
@@ -18,6 +18,7 @@ module Polaris
       back_url: nil,
       prev_url: nil,
       next_url: nil,
+      pagination_label: nil,
       narrow_width: false,
       full_width: false,
       divider: false,
@@ -30,6 +31,7 @@ module Polaris
       @back_url = back_url
       @prev_url = prev_url
       @next_url = next_url
+      @pagination_label = pagination_label
       @narrow_width = narrow_width
       @full_width = full_width
       @divider = divider


### PR DESCRIPTION
`[pagination_component](https://polarisviewcomponents.org/lookbook/inspect/pagination/with_label)` has `label` option, however we do not have such an option in the `page_component`, where we also have prev/next url. 

added `pagination_label` to `page_component`.

example without `@pagination_label` defined:

<img width="410" alt="Screenshot 2023-11-15 at 20 21 03" src="https://github.com/baoagency/polaris_view_components/assets/13472945/7f687adc-5bef-4796-a8f5-5af886f88370">

with `@pagination_label`:

<img width="413" alt="Screenshot 2023-11-15 at 20 20 54" src="https://github.com/baoagency/polaris_view_components/assets/13472945/433648cd-32cf-4727-99da-ce0e33864d1b">
