### PR TITLE
add @subtitle option to Card

### DIFF
--- a/app/components/polaris/card_component.html.erb
+++ b/app/components/polaris/card_component.html.erb
@@ -20,9 +20,17 @@
   <% if content.present? %>
     <% if @sectioned %>
       <%= render Polaris::Card::SectionComponent.new do %>
+        <% if @subtitle.present? %>
+          <%= polaris_text_style(variation: :subdued) { @subtitle } %>
+          <%= polaris_spacer(vertical: :loose) %>
+        <% end %>
         <%= content %>
       <% end %>
     <% else %>
+      <% if @subtitle.present? %>
+        <%= polaris_text_style(variation: :subdued) { @subtitle } %>
+        <%= polaris_spacer(vertical: :loose) %>
+      <% end %>
       <%= content %>
     <% end %>
   <% end %>

--- a/app/components/polaris/card_component.rb
+++ b/app/components/polaris/card_component.rb
@@ -19,6 +19,7 @@ module Polaris
 
     def initialize(
       title: "",
+      subtitle: nil,
       actions: [],
       sectioned: true,
       subdued: false,
@@ -26,6 +27,7 @@ module Polaris
       **system_arguments
     )
       @title = title
+      @subtitle = subtitle
       @actions = actions
       @sectioned = sectioned
       @footer_action_alignment = footer_action_alignment

--- a/demo/app/previews/card_component_preview.rb
+++ b/demo/app/previews/card_component_preview.rb
@@ -3,6 +3,10 @@ class CardComponentPreview < ViewComponent::Preview
   def default
   end
 
+  # A description of the card’s content.
+  def card_with_subtitle
+  end
+
   # Use for less important card actions, or actions merchants may do before reviewing the contents of the card. For example, merchants may want to add items to a card containing a long list, or enter a customer’s new address.
   def card_with_header_actions
   end

--- a/demo/app/previews/card_component_preview/card_with_subtitle.html.erb
+++ b/demo/app/previews/card_component_preview/card_with_subtitle.html.erb
@@ -1,0 +1,6 @@
+<%= polaris_card(
+  title: "Online store dashboard",
+  subtitle: "A description of the card’s content."
+) do %>
+  <p>View a summary of your online store’s performance.</p>
+<% end %>

--- a/test/components/polaris/card_component_test.rb
+++ b/test/components/polaris/card_component_test.rb
@@ -95,6 +95,15 @@ class CardComponentTest < Minitest::Test
     assert_selector ".Polaris-LegacyCard__Subsection", text: "Subsection"
   end
 
+  def test_renders_card_with_subtitle
+    render_inline(Polaris::CardComponent.new(
+      title: "Card",
+      subtitle: "Subtitle"
+    )) { "Body" }
+
+    assert_selector ".Polaris-Text--subdued", text: "Subtitle"
+  end
+
   def test_renders_card_with_header_actions
     render_inline(Polaris::CardComponent.new(
       title: "Card",


### PR DESCRIPTION
preview:
<img width="1277" alt="Screenshot 2023-11-27 at 13 16 15" src="https://github.com/baoagency/polaris_view_components/assets/13472945/19245226-d274-42cf-97d0-744257029b07">
example usage:
<img width="701" alt="Screenshot 2023-11-27 at 13 17 36" src="https://github.com/baoagency/polaris_view_components/assets/13472945/fbac875a-bbd5-4fcf-a0b9-b3f1f3f383ad">
