### PR TITLE
Fix page title length check when it has html

### DIFF
--- a/app/components/polaris/page_component.rb
+++ b/app/components/polaris/page_component.rb
@@ -13,7 +13,6 @@ module Polaris
 
     def initialize(
       title: nil,
-      force_medium_title: nil,
       subtitle: nil,
       compact_title: false,
       back_url: nil,
@@ -27,7 +26,6 @@ module Polaris
       **system_arguments
     )
       @title = title
-      @force_medium_title = force_medium_title
       @subtitle = subtitle
       @compact_title = compact_title
       @back_url = back_url
@@ -42,12 +40,13 @@ module Polaris
     end
 
     def header_arguments
+      title_length = strip_tags(@title).strip.length
       {
         tag: "div",
         classes: class_names(
           "Polaris-Page-Header--mobileView",
-          "Polaris-Page-Header--mediumTitle": @title.present? && (@force_medium_title || @title.length <= LONG_TITLE),
-          "Polaris-Page-Header--longTitle": @title.present? && @title.length > LONG_TITLE && !@force_medium_title,
+          "Polaris-Page-Header--mediumTitle": @title.present? && title_length <= LONG_TITLE,
+          "Polaris-Page-Header--longTitle": @title.present? && title_length > LONG_TITLE,
           "Polaris-Page-Header--hasNavigation": @back_url.present?,
           "Polaris-Page-Header--noBreadcrumbs": @back_url.blank?
         )

--- a/app/components/polaris/page_component.rb
+++ b/app/components/polaris/page_component.rb
@@ -2,6 +2,8 @@
 
 module Polaris
   class PageComponent < Polaris::Component
+    include ActionView::Helpers::SanitizeHelper
+
     LONG_TITLE = 34
 
     renders_one :title_metadata

--- a/app/components/polaris/page_component.rb
+++ b/app/components/polaris/page_component.rb
@@ -42,7 +42,7 @@ module Polaris
     end
 
     def header_arguments
-      title_length = strip_tags(@title).strip.length
+      title_length = strip_tags(@title)&.strip.length
       {
         tag: "div",
         classes: class_names(

--- a/app/components/polaris/page_component.rb
+++ b/app/components/polaris/page_component.rb
@@ -42,7 +42,6 @@ module Polaris
     end
 
     def header_arguments
-      title_length = strip_tags(@title)&.strip.length
       {
         tag: "div",
         classes: class_names(
@@ -53,6 +52,11 @@ module Polaris
           "Polaris-Page-Header--noBreadcrumbs": @back_url.blank?
         )
       }
+    end
+
+    def title_length
+      stripped_title = strip_tags(@title)&.strip
+      stripped_title.present? ? stripped_title.length : 0
     end
 
     def title_arguments

--- a/app/components/polaris/page_component.rb
+++ b/app/components/polaris/page_component.rb
@@ -13,6 +13,7 @@ module Polaris
 
     def initialize(
       title: nil,
+      force_medium_title: nil,
       subtitle: nil,
       compact_title: false,
       back_url: nil,
@@ -26,6 +27,7 @@ module Polaris
       **system_arguments
     )
       @title = title
+      @force_medium_title = force_medium_title
       @subtitle = subtitle
       @compact_title = compact_title
       @back_url = back_url
@@ -44,8 +46,8 @@ module Polaris
         tag: "div",
         classes: class_names(
           "Polaris-Page-Header--mobileView",
-          "Polaris-Page-Header--mediumTitle": @title.present? && @title.length <= LONG_TITLE,
-          "Polaris-Page-Header--longTitle": @title.present? && @title.length > LONG_TITLE,
+          "Polaris-Page-Header--mediumTitle": @title.present? && (@force_medium_title || @title.length <= LONG_TITLE),
+          "Polaris-Page-Header--longTitle": @title.present? && @title.length > LONG_TITLE && !@force_medium_title,
           "Polaris-Page-Header--hasNavigation": @back_url.present?,
           "Polaris-Page-Header--noBreadcrumbs": @back_url.blank?
         )


### PR DESCRIPTION
expectation:
<img width="532" alt="Screenshot 2024-01-02 at 20 13 55" src="https://github.com/baoagency/polaris_view_components/assets/13472945/5e1a59fb-be2d-41e9-81f6-b6fcfb3e4dc7">
reality:
<img width="545" alt="Screenshot 2024-01-02 at 20 15 38" src="https://github.com/baoagency/polaris_view_components/assets/13472945/c1cca8dc-936d-4601-95d0-220faee5ad1e">

this is because the inline title length can be max 34 characters.

but I am using some html around the actual text, so I have more characters.

this way I can ensure that title is inline


```ruby
<% title_with_checkbox_selected_count = capture do %>
  <div>
    <span data-checkbox-selected-count-target="counter"></span>
    <%= t('.orders_selected') %>
  </div>
<% end %>

<%= polaris_page(
  title: title_with_checkbox_selected_count,
+  force_medium_title: true 
...
%>
```