### PR TITLE
Popover fix - from using in real apps

### DIFF
--- a/app/assets/stylesheets/polaris_view_components.css
+++ b/app/assets/stylesheets/polaris_view_components.css
@@ -381,7 +381,9 @@
 }.Polaris-Popover__PopoverOverlay--closed {
   visibility: hidden;
   pointer-events: none;
-}/* Filters */.Polaris-LegacyFilters-ConnectedFilterControl__RightContainer .Polaris-LegacyFilters-ConnectedFilterControl__Item > div > div > button {
+}/* Filters */.Polaris-LegacyFilters-ConnectedFilterControl__RightContainer .Polaris-LegacyFilters-ConnectedFilterControl__Item {
+    z-index: auto;
+  }.Polaris-LegacyFilters-ConnectedFilterControl__RightContainer .Polaris-LegacyFilters-ConnectedFilterControl__Item > div > div > button {
       margin-right: -1px;
       border-radius: 0;
     }.Polaris-LegacyFilters-ConnectedFilterControl__RightContainer .Polaris-LegacyFilters-ConnectedFilterControl__Item:first-of-type > div > div > button {

--- a/app/assets/stylesheets/polaris_view_components/custom.pcss
+++ b/app/assets/stylesheets/polaris_view_components/custom.pcss
@@ -65,9 +65,10 @@ a.Polaris-Tag__Button {
 }
 
 /* Filters */
-
 .Polaris-LegacyFilters-ConnectedFilterControl__RightContainer {
   .Polaris-LegacyFilters-ConnectedFilterControl__Item {
+    z-index: auto;
+
     & > div > div > button {
       margin-right: -1px;
       border-radius: 0;

--- a/app/components/polaris/filters_component.rb
+++ b/app/components/polaris/filters_component.rb
@@ -77,7 +77,7 @@ module Polaris
           style: ("width: #{@width}" if @width.present?),
           position: :below,
           alignment: :left,
-          append_to_body: true
+          append_to_body: false
         }
       end
 

--- a/test/components/polaris/filters_component_test.rb
+++ b/test/components/polaris/filters_component_test.rb
@@ -26,9 +26,9 @@ class FiltersComponentTest < Minitest::Test
             assert_selector "[data-polaris-popover-target='activator']" do
               assert_selector ".Polaris-Button", text: "Filter"
             end
+            assert_selector "[data-polaris-popover-target='popover']", text: "Content"
           end
         end
-        assert_selector "[data-polaris-popover-target='template']", visible: :hidden
       end
     end
   end


### PR DESCRIPTION
- Previous change to use append_to_body on Filters component caused Stimulus actions to not fire. So now we set the z-index properly, which fixes the original overlap issue.