### PR TITLE
Trigger text field #clearErrorMessages on click

### DIFF
--- a/app/components/polaris/text_field_component.rb
+++ b/app/components/polaris/text_field_component.rb
@@ -163,7 +163,7 @@ module Polaris
           "Polaris-TextField__Input--suffixed": @suffix.present?
         )
         if @clear_errors_on_focus
-          prepend_option(opts[:data], :action, "focus->polaris-text-field#clearErrorMessages")
+          prepend_option(opts[:data], :action, "click->polaris-text-field#clearErrorMessages")
         end
         prepend_option(opts[:data], :action, "polaris-text-field#syncValue")
       end

--- a/test/components/polaris/text_field_component_test.rb
+++ b/test/components/polaris/text_field_component_test.rb
@@ -288,7 +288,7 @@ class TextFieldComponentTest < Minitest::Test
       clear_errors_on_focus: true
     ))
 
-    assert_selector "input[name=input_name][data-action~='focus->polaris-text-field#clearErrorMessages']"
+    assert_selector "input[name=input_name][data-action~='click->polaris-text-field#clearErrorMessages']"
 
     render_inline(Polaris::TextFieldComponent.new(
       name: :input_name,
@@ -298,6 +298,6 @@ class TextFieldComponentTest < Minitest::Test
       input_options: {data: {action: "custom#action"}}
     ))
 
-    assert_selector "input[name=input_name][data-action~='focus->polaris-text-field#clearErrorMessages']"
+    assert_selector "input[name=input_name][data-action~='click->polaris-text-field#clearErrorMessages']"
   end
 end


### PR DESCRIPTION
Fixes inline message for current field not being displayed when form submitted vie Return key.