### PR TITLE
Add support for borderless cards

### DIFF
--- a/app/assets/stylesheets/polaris_view_components.css
+++ b/app/assets/stylesheets/polaris_view_components.css
@@ -361,6 +361,11 @@
     padding-top: var(--p-space-100);
   }html[class~="Polaris-Summer-Editions-2023"] .Polaris-LegacyCard.Polaris-LegacyCard--withoutTitle .Polaris-LegacyCard__Section:first-child {
       padding-top: var(--p-space-400);
+    }html[class~="Polaris-Summer-Editions-2023"] .Polaris-LegacyCard.Polaris-LegacyCard--borderless {
+    border: none;
+    box-shadow: none;
+  }html[class~="Polaris-Summer-Editions-2023"] .Polaris-LegacyCard.Polaris-LegacyCard--borderless::before {
+      content: none;
     }.Polaris--hidden {
   display: none !important;
 }/* Add missing 1/4 section for layout */@media (min-width: 30.625em) {

--- a/app/assets/stylesheets/polaris_view_components/card.pcss
+++ b/app/assets/stylesheets/polaris_view_components/card.pcss
@@ -38,4 +38,13 @@ html[class~="Polaris-Summer-Editions-2023"] .Polaris-LegacyCard {
       padding-top: var(--p-space-400);
     }
   }
+
+  &.Polaris-LegacyCard--borderless {
+    border: none;
+    box-shadow: none;
+
+    &::before {
+      content: none;
+    }
+  }
 }

--- a/app/components/polaris/card_component.rb
+++ b/app/components/polaris/card_component.rb
@@ -22,6 +22,7 @@ module Polaris
       actions: [],
       sectioned: true,
       subdued: false,
+      borders: true,
       footer_action_alignment: FOOTER_ACTION_ALIGNMENT_DEFAULT,
       **system_arguments
     )
@@ -29,6 +30,7 @@ module Polaris
       @actions = actions
       @sectioned = sectioned
       @subdued = subdued
+      @borders = borders
       @footer_action_alignment = footer_action_alignment
       @system_arguments = system_arguments
     end
@@ -40,7 +42,8 @@ module Polaris
           opts[:classes],
           "Polaris-LegacyCard",
           "Polaris-LegacyCard--subdued": @subdued,
-          "Polaris-LegacyCard--withoutTitle": @title.blank?
+          "Polaris-LegacyCard--withoutTitle": @title.blank?,
+          "Polaris-LegacyCard--borderless": !@borders
         )
       end
     end

--- a/demo/app/previews/card_component_preview.rb
+++ b/demo/app/previews/card_component_preview.rb
@@ -75,4 +75,7 @@ class CardComponentPreview < ViewComponent::Preview
 
   def without_title
   end
+
+  def borderless
+  end
 end

--- a/demo/app/previews/card_component_preview/borderless.html.erb
+++ b/demo/app/previews/card_component_preview/borderless.html.erb
@@ -1,0 +1,3 @@
+<%= polaris_card(title: "Online store dashboard", borders: false) do %>
+  <p>View a summary of your online store’s performance.</p>
+<% end %>


### PR DESCRIPTION
```erb
<%= polaris_card(title: "Online store dashboard", borders: false) do %>
  <p>View a summary of your online store’s performance.</p>
<% end %>
```

![CleanShot 2024-04-02 at 13 20 41@2x](https://github.com/baoagency/polaris_view_components/assets/839922/c7a23635-03b6-4499-b8ae-470ab05f1915)
