### PR TITLE
Support `button_to` on navigation item

### DIFF
--- a/app/components/polaris/navigation/item_component.html.erb
+++ b/app/components/polaris/navigation/item_component.html.erb
@@ -1,19 +1,37 @@
 <%= render Polaris::BaseComponent.new(**system_arguments) do %>
   <div class="Polaris-Navigation__ItemWrapper">
     <div class="Polaris-Navigation__ItemInnerWrapper">
-      <%= link_to @url, **link_arguments do %>
-        <% if @icon.present? %>
-          <div class="Polaris-Navigation__Icon">
-            <%= polaris_icon(name: @icon) %>
-          </div>
+      <% if @action_type == :link %>
+        <%= link_to @url, **link_arguments do %>
+          <% if @icon.present? %>
+            <div class="Polaris-Navigation__Icon">
+              <%= polaris_icon(name: @icon) %>
+            </div>
+          <% end %>
+          <span class="Polaris-Navigation__Text">
+            <%= @label %>
+          </span>
+          <% if @badge.present? %>
+            <div class="Polaris-Navigation__Badge">
+              <%= polaris_badge { @badge } %>
+            </div>
+          <% end %>
         <% end %>
-        <span class="Polaris-Navigation__Text">
-          <%= @label %>
-        </span>
-        <% if @badge.present? %>
-          <div class="Polaris-Navigation__Badge">
-            <%= polaris_badge { @badge } %>
-          </div>
+      <% else %>
+        <%= button_to @url, **link_arguments do %>
+          <% if @icon.present? %>
+            <div class="Polaris-Navigation__Icon">
+              <%= polaris_icon(name: @icon) %>
+            </div>
+          <% end %>
+          <span class="Polaris-Navigation__Text">
+            <%= @label %>
+          </span>
+          <% if @badge.present? %>
+            <div class="Polaris-Navigation__Badge">
+              <%= polaris_badge { @badge } %>
+            </div>
+          <% end %>
         <% end %>
       <% end %>
       <% if secondary_actions.present? %>

--- a/app/components/polaris/navigation/item_component.rb
+++ b/app/components/polaris/navigation/item_component.rb
@@ -25,7 +25,7 @@ class Polaris::Navigation::ItemComponent < Polaris::Component
     @external = external
     @system_arguments = system_arguments
     @action_type = action_type
-    @link_arguments = link_arguments.merge
+    @link_arguments = link_arguments
   end
 
   def system_arguments

--- a/app/components/polaris/navigation/item_component.rb
+++ b/app/components/polaris/navigation/item_component.rb
@@ -12,6 +12,7 @@ class Polaris::Navigation::ItemComponent < Polaris::Component
     selected: false,
     disabled: false,
     external: false,
+    action_type: :link,
     link_arguments: {},
     **system_arguments
   )
@@ -23,7 +24,8 @@ class Polaris::Navigation::ItemComponent < Polaris::Component
     @disabled = disabled
     @external = external
     @system_arguments = system_arguments
-    @link_arguments = link_arguments
+    @action_type = action_type
+    @link_arguments = link_arguments.merge
   end
 
   def system_arguments


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves #423 

### WHAT is this pull request doing?

Support `button_to` on navigation item

### Usage

```html.erb
<%= polaris_navigation do |navigation| %>
  <% navigation.with_section do |section| %>
    <% section.with_item(
      url: destroy_user_session_path,
      label: "Logout",
      icon: "ExitIcon",
      action_type: :button,
      link_arguments: {
        method: :delete,
        data: {
          turbo: false
        }
      }
    ) %>
  <% end %>
<% end %>
```