### PR TITLE
Fix Polaris `destructive` button active color

### DIFF
--- a/app/assets/stylesheets/polaris_view_components.css
+++ b/app/assets/stylesheets/polaris_view_components.css
@@ -317,7 +317,9 @@
     --pc-button-color-active: var(--p-color-bg-fill-critical-active);
     --pc-button-color-depressed: var(--p-color-bg-fill-critical-selected);
     box-shadow: var(--p-shadow-button-primary-critical);
-  }/* Primary */html[class~="Polaris-Summer-Editions-2023"] .Polaris-Button.Polaris-Button--primary {
+  }html[class~="Polaris-Summer-Editions-2023"] .Polaris-Button.Polaris-Button--destructive:active, html[class~="Polaris-Summer-Editions-2023"] .Polaris-Button.Polaris-Button--destructive:is(.Polaris-Button--primary):active {
+      background: var(--pc-button-color-active);
+    }/* Primary */html[class~="Polaris-Summer-Editions-2023"] .Polaris-Button.Polaris-Button--primary {
     --pc-button-bg-gradient: var(--p-color-button-gradient-bg-fill);
     --pc-button-color: var(--pc-button-bg-gradient), var(--p-color-bg-fill-brand);
     --pc-button-text: var(--p-color-bg-surface);

--- a/app/assets/stylesheets/polaris_view_components/button.pcss
+++ b/app/assets/stylesheets/polaris_view_components/button.pcss
@@ -1,6 +1,8 @@
 /* Polaris no longer uses different button styling depending on the context,
    so we can override all buttons at once. */
 html[class~="Polaris-Summer-Editions-2023"] .Polaris-Button {
+
+
   &:not(.Polaris-Button--plain) {
     &:hover {
       box-shadow: var(--pc-button-shadow-hover);
@@ -60,6 +62,10 @@ html[class~="Polaris-Summer-Editions-2023"] .Polaris-Button {
     --pc-button-color-active: var(--p-color-bg-fill-critical-active);
     --pc-button-color-depressed: var(--p-color-bg-fill-critical-selected);
     box-shadow: var(--p-shadow-button-primary-critical);
+
+    &:active {
+      background: var(--pc-button-color-active);
+    }
   }
 
   /* Primary */


### PR DESCRIPTION
### WHAT is this pull request doing?

Fix Polaris `destructive` button active color 

### Before
![image](https://github.com/user-attachments/assets/02d68d3d-f8ec-4cd8-8a99-b2d638db1280)

### After
![image](https://github.com/user-attachments/assets/71bd683d-8eaa-40fc-adbb-ca33c4a191eb)
