### PR TITLE
Fix FormBuilder to correctly forward block to TextField

### DIFF
--- a/app/helpers/polaris/form_builder.rb
+++ b/app/helpers/polaris/form_builder.rb
@@ -54,7 +54,7 @@ module Polaris
       if options[:error_hidden] && options[:error]
         options[:error] = !!options[:error]
       end
-      render Polaris::TextFieldComponent.new(form: self, attribute: method, **options, &block)
+      render Polaris::TextFieldComponent.new(form: self, attribute: method, **options), &block
     end
 
     def polaris_select(method, **options, &block)

--- a/demo/app/previews/form_builder_component_preview/text_field.html.erb
+++ b/demo/app/previews/form_builder_component_preview/text_field.html.erb
@@ -5,18 +5,18 @@
 <%= polaris_spacer(vertical: :base) %>
 
 <%= form_with(model: product, builder: Polaris::FormBuilder) do |form| %>
-    <%= form.polaris_text_field(:title, help_text: "Note about text field") do |c| %>
-        <% c.with_connected_left do %>
-            <%= polaris_select(
-              name: :weight_unit,
-              label: "Weight unit",
-              label_hidden: true,
-              options: { "kd" => "kg", "lb" => "lb" },
-              selected: "kg",
-            ) %>
-          <% end %>
-          <% c.with_connected_right do %>
-            <%= polaris_button { "Submit" } %>
-          <% end %>
+  <%= form.polaris_text_field(:title, help_text: "Note about text field") do |c| %>
+    <% c.with_connected_left do %>
+      <%= polaris_select(
+        name: :weight_unit,
+        label: "Weight unit",
+        label_hidden: true,
+        options: { "kd" => "kg", "lb" => "lb" },
+        selected: "kg",
+      ) %>
     <% end %>
+    <% c.with_connected_right do %>
+      <%= polaris_button { "Submit" } %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/demo/app/previews/form_builder_component_preview/text_field.html.erb
+++ b/demo/app/previews/form_builder_component_preview/text_field.html.erb
@@ -1,3 +1,22 @@
 <%= form_with(model: product, builder: Polaris::FormBuilder) do |form| %>
   <%= form.polaris_text_field(:title, help_text: "Note about text field") %>
 <% end %>
+
+<%= polaris_spacer(vertical: :base) %>
+
+<%= form_with(model: product, builder: Polaris::FormBuilder) do |form| %>
+    <%= form.polaris_text_field(:title, help_text: "Note about text field") do |c| %>
+        <% c.with_connected_left do %>
+            <%= polaris_select(
+              name: :weight_unit,
+              label: "Weight unit",
+              label_hidden: true,
+              options: { "kd" => "kg", "lb" => "lb" },
+              selected: "kg",
+            ) %>
+          <% end %>
+          <% c.with_connected_right do %>
+            <%= polaris_button { "Submit" } %>
+          <% end %>
+    <% end %>
+<% end %>

--- a/test/helpers/polaris/form_builder_test.rb
+++ b/test/helpers/polaris/form_builder_test.rb
@@ -58,6 +58,25 @@ class Polaris::ViewHelperTest < ActionView::TestCase
     end
   end
 
+  test "#polaris_text_field_with_block" do
+    @rendered_content = @builder.polaris_text_field(:title, help_text: "Help Text") do |c|
+      c.with_connected_right do
+        polaris_button { "Submit" }
+      end
+    end
+
+    assert_selector ".Polaris-Label" do
+      assert_selector "label", text: "Title"
+    end
+    assert_selector ".Polaris-TextField" do
+      assert_selector %(input[name="product[title]"])
+      assert_selector ".Polaris-Labelled__HelpText", text: "Help Text"
+    end
+    assert_selector ".Polaris-Button" do
+      assert_selector "div", text: "Submit"
+    end
+  end
+
   test "#polaris_select" do
     @rendered_content = @builder.polaris_select(:status, options: {"Active" => "active", "Draft" => "draft"})
 


### PR DESCRIPTION
I noticed that when using a block on the `FormBuilder#polaris_text_field` (eg: to add connected fields), the block wasn't correctly passed to `Polaris::TextFieldComponent.new` and the final render wasn't complete.

I added tests to cover the issue, but i'm not 100% confident on the change and i wish i could get a code review.
Also, i'm unsure if other methods sharing the same pattern are actually suffering the same issue. If yes i can fix all of them and add tests.

Thanks for your help!
