### PR TITLE
Fix DataTablesComponent hoverable option

### DIFF
--- a/app/components/polaris/data_table_component.rb
+++ b/app/components/polaris/data_table_component.rb
@@ -35,7 +35,7 @@ module Polaris
           "Polaris-DataTable"
         )
         args[:data] ||= {}
-        args[:data][:controller] = "polaris-data-table"
+        args[:data][:controller] = "polaris-data-table" if @hoverable
       end
     end
 


### PR DESCRIPTION
Currently the `hoverable:` option on DataTablesComponent cannot be set to false, as the stimulus controller is added anyway. This ensures it's only added when hoverable is true.