### PR TITLE
Popover fixes

### DIFF
--- a/app/assets/javascripts/polaris_view_components.js
+++ b/app/assets/javascripts/polaris_view_components.js
@@ -2134,6 +2134,10 @@ class Popover extends Controller {
     if (this.cleanup) {
       this.cleanup();
     }
+    if (this.target && this.appendToBodyValue) {
+      this.target.remove();
+    }
+    this._target = null;
   }
   updatePosition() {
     if (this.cleanup) {
@@ -2142,7 +2146,10 @@ class Popover extends Controller {
     this.cleanup = autoUpdate(this.activator, this.target, (() => {
       computePosition(this.activator, this.target, {
         placement: this.placementValue,
-        middleware: [ offset(5), flip(), shift({
+        middleware: [ offset(5), flip({
+          fallbackPlacements: [ this.placementValue ],
+          fallbackStrategy: "bestFit"
+        }), shift({
           padding: 5
         }) ]
       }).then((({x: x, y: y}) => {


### PR DESCRIPTION
1. Fixes issue with `append_to_body: true` not removing itself completely on dom changes. For example, if the menu was open, it would remain in place when the popover element was removed.
2. Fixes issue with `placement: ` not respecting the chosen position during flip calculation.