### PR TITLE
Fix pagination button disabled state.

### DIFF
--- a/app/assets/stylesheets/polaris_view_components.css
+++ b/app/assets/stylesheets/polaris_view_components.css
@@ -595,14 +595,13 @@
     font-size: var(--p-font-size-500);
     line-height: var(--p-font-line-height-600);
   }html[class~="Polaris-Summer-Editions-2023"] [aria-label='Pagination'] .Polaris-Button {
-    background-color: var(--p-color-bg-fill-tertiary);
     border: none !important;
     box-shadow: none;
-  }html[class~="Polaris-Summer-Editions-2023"] [aria-label='Pagination'] .Polaris-Button:hover {
-      background-color: var(--p-color-bg-fill-tertiary-hover);
-      box-shadow: none;
-      border: none;
-    }html[class~="Polaris-Summer-Editions-2023"] .Polaris-Popover .Polaris-Popover__Content .Polaris-Popover__Pane:first-child > .Polaris-Popover__Section > .Polaris-Box {
+  }html[class~="Polaris-Summer-Editions-2023"] [aria-label='Pagination'] .Polaris-Button:not([disabled]) {
+      background-color: var(--p-color-bg-fill-tertiary);
+    }html[class~="Polaris-Summer-Editions-2023"] [aria-label='Pagination'] .Polaris-Button:not([disabled]):hover {
+        background-color: var(--p-color-bg-fill-tertiary-hover);
+      }html[class~="Polaris-Summer-Editions-2023"] .Polaris-Popover .Polaris-Popover__Content .Polaris-Popover__Pane:first-child > .Polaris-Popover__Section > .Polaris-Box {
     padding: var(--p-space-300) var(--p-space-400) var(--p-space-100);
   }html[class~="Polaris-Summer-Editions-2023"] .Polaris-Popover .Polaris-Popover__Content .Polaris-Popover__Pane:last-child > .Polaris-Popover__Section > .Polaris-Box {
     padding: var(--p-space-300) var(--p-space-300);

--- a/app/assets/stylesheets/polaris_view_components/pagination.pcss
+++ b/app/assets/stylesheets/polaris_view_components/pagination.pcss
@@ -1,13 +1,14 @@
 html[class~="Polaris-Summer-Editions-2023"] [aria-label='Pagination'] {
   .Polaris-Button {
-    background-color: var(--p-color-bg-fill-tertiary);
     border: none !important;
     box-shadow: none;
 
-    &:hover {
-      background-color: var(--p-color-bg-fill-tertiary-hover);
-      box-shadow: none;
-      border: none;
+    &:not([disabled]) {
+      background-color: var(--p-color-bg-fill-tertiary);
+
+      &:hover {
+        background-color: var(--p-color-bg-fill-tertiary-hover);
+      }
     }
   }
 }


### PR DESCRIPTION
Pagination button disabled state isn't getting the BG style properly. This fixes that.

The issue is apparent on white backgrounds only (which is prob why it was missed).

Before:
<img width="510" alt="Before - With Label : Pagination : Polaris ViewComponents 2025-01-28 10-17-36" src="https://github.com/user-attachments/assets/c2ff78a7-87c0-4b9d-9eeb-065f27123c04" />

After:
<img width="529" alt="After - With Label : Pagination : Polaris ViewComponents 2025-01-28 10-17-36" src="https://github.com/user-attachments/assets/4739d5a6-9a0b-4143-a793-edffc694d197" />

Shopify:
<img width="323" alt="Pagination — Shopify Polaris 2025-01-28 10-23-03" src="https://github.com/user-attachments/assets/c9602df9-3558-4550-a4be-8f8742ccc7d1" />


Might need retina screen to see the difference as it is subtle.

Also FYI, seems like the Shopify one is slightly different, but we should fix the CSS before equalizing it by tweaking the variables later.