### PR TITLE
Add Extra Small thumbnail component.

### DIFF
--- a/app/components/polaris/thumbnail_component.rb
+++ b/app/components/polaris/thumbnail_component.rb
@@ -8,6 +8,7 @@ module Polaris
 
     SIZE_DEFAULT = :medium
     SIZE_MAPPINGS = {
+      extra_small: "Polaris-Thumbnail--sizeExtraSmall",
       small: "Polaris-Thumbnail--sizeSmall",
       medium: "Polaris-Thumbnail--sizeMedium",
       large: "Polaris-Thumbnail--sizeLarge"
@@ -29,6 +30,8 @@ module Polaris
       @size = size
       @source = source
       @transparent = transparent
+
+      @size = :extra_small if [:xsmall, :x_small, :xs].include?(@size)
 
       @system_arguments = system_arguments
     end

--- a/demo/app/previews/thumbnail_component_preview.rb
+++ b/demo/app/previews/thumbnail_component_preview.rb
@@ -2,6 +2,9 @@ class ThumbnailComponentPreview < ViewComponent::Preview
   def default
   end
 
+  def extra_small
+  end
+
   def small
   end
 

--- a/demo/app/previews/thumbnail_component_preview/extra_small.html.erb
+++ b/demo/app/previews/thumbnail_component_preview/extra_small.html.erb
@@ -1,0 +1,5 @@
+<%= polaris_thumbnail(
+  source: "https://burst.shopifycdn.com/photos/black-leather-choker-necklace_373x@2x.jpg",
+  alt: "Black choker necklace",
+  size: :extra_small,
+) %>


### PR DESCRIPTION
Polaris has an Extra Small size for thumbnails. This PR adds that size option in the library.

<img width="638" alt="Extra Small :: Thumbnail :: Polaris ViewComponents 2025-01-28 10-32-12" src="https://github.com/user-attachments/assets/9cda8d08-3c40-4107-912c-3c7b2ae9ca01" />
