### PR TITLE
Allow navigation component items to take badge sub-components

### DIFF
--- a/app/components/polaris/navigation/item_component.html.erb
+++ b/app/components/polaris/navigation/item_component.html.erb
@@ -11,9 +11,9 @@
           <span class="Polaris-Navigation__Text">
             <%= @label %>
           </span>
-          <% if @badge.present? %>
+          <% if badge? || @badge.present? %>
             <div class="Polaris-Navigation__Badge">
-              <%= polaris_badge { @badge } %>
+              <%= badge? ? badge : (polaris_badge { @badge }) %>
             </div>
           <% end %>
         <% end %>
@@ -27,9 +27,9 @@
           <span class="Polaris-Navigation__Text">
             <%= @label %>
           </span>
-          <% if @badge.present? %>
+          <% if badge? || @badge.present? %>
             <div class="Polaris-Navigation__Badge">
-              <%= polaris_badge { @badge } %>
+              <%= badge? ? badge : (polaris_badge { @badge }) %>
             </div>
           <% end %>
         <% end %>

--- a/app/components/polaris/navigation/item_component.rb
+++ b/app/components/polaris/navigation/item_component.rb
@@ -1,4 +1,5 @@
 class Polaris::Navigation::ItemComponent < Polaris::Component
+  renders_one :badge, Polaris::BadgeComponent
   renders_many :sub_items, Polaris::Navigation::ItemComponent
   renders_many :secondary_actions, "SecondaryActionComponent"
 

--- a/test/components/polaris/navigation_component_test.rb
+++ b/test/components/polaris/navigation_component_test.rb
@@ -42,6 +42,18 @@ class NavigationComponentTest < Minitest::Test
     end
   end
 
+  def test_item_badge_child
+    render_inline(Polaris::NavigationComponent.new) do |navigation|
+      navigation.with_item(url: "/path1", label: "Item 1", icon: "HomeIcon") do |item|
+        item.with_badge(status: :success) { "SUCCESS" }
+      end
+    end
+
+    assert_selector ".Polaris-Navigation__ListItem .Polaris-Navigation__Item" do
+      assert_selector ".Polaris-Navigation__Badge > .Polaris-Badge--statusSuccess", text: "SUCCESS"
+    end
+  end
+
   def test_multiple_sections
     render_inline(Polaris::NavigationComponent.new) do |navigation|
       navigation.with_section do |section|


### PR DESCRIPTION
# Why?
Sometimes you want to show a a warning badge in the nav to direct people to that location to check some errors, but the current implementation only lets you set a value or `nil`.

# What?
You can still set the value via the item `badge` attribute, however it will now also check for the sub-component so you can do this to show a critical errors count badge:
```ruby
item.with_badge(status: :critical) { "1" }
```
