### PR TITLE
Add NewTabs component

### DIFF
--- a/app/components/polaris/new_tabs/tab_component.html.erb
+++ b/app/components/polaris/new_tabs/tab_component.html.erb
@@ -4,8 +4,8 @@
       <% stack.with_item do %>
         <%= polaris_text(variant: :bodySm, as: :span, font_weight: :medium) { @title } %>
       <% end %>
-      <% stack.with_item do %>
-        <% if badge.present? %>
+      <% if badge.present? %>
+        <% stack.with_item do %>
           <%= badge %>
         <% end %>
       <% end %>

--- a/app/components/polaris/new_tabs/tab_component.html.erb
+++ b/app/components/polaris/new_tabs/tab_component.html.erb
@@ -1,0 +1,14 @@
+<li class="Polaris-Tabs__TabContainer" role="presentation">
+  <%= render(Polaris::BaseComponent.new(**system_arguments)) do %>
+    <%= polaris_stack(alignment: :center, distribution: :center, spacing: :tight) do |stack| %>
+      <% stack.with_item do %>
+        <%= polaris_text(variant: :bodySm, as: :span, font_weight: :medium) { @title } %>
+      <% end %>
+      <% stack.with_item do %>
+        <% if badge.present? %>
+          <%= badge %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+</li>

--- a/app/components/polaris/new_tabs/tab_component.rb
+++ b/app/components/polaris/new_tabs/tab_component.rb
@@ -1,0 +1,34 @@
+class Polaris::NewTabs::TabComponent < Polaris::Component
+  renders_one :badge, Polaris::BadgeComponent
+
+  def initialize(
+    title:,
+    url: nil,
+    active: false,
+    **system_arguments
+  )
+    @title = title
+    @url = url
+    @active = active
+    @system_arguments = system_arguments
+  end
+
+  def system_arguments
+    @system_arguments.tap do |opts|
+      opts[:rol] = "tab"
+      opts[:tabindex] = "0"
+      if @url.present?
+        opts[:tag] = "a"
+        opts[:href] = @url
+      else
+        opts[:tag] = "button"
+        opts[:type] = "button"
+      end
+      opts[:classes] = class_names(
+        @system_arguments[:classes],
+        "Polaris-Tabs__Tab",
+        "Polaris-Tabs__Tab--active": @active
+      )
+    end
+  end
+end

--- a/app/components/polaris/new_tabs_component.html.erb
+++ b/app/components/polaris/new_tabs_component.html.erb
@@ -1,0 +1,14 @@
+<%= polaris_box(
+  padding_block_start: {xs: "0", sm: "0", md: "2"},
+  padding_block_end: {xs: "0", sm: "0", md: "2"},
+  padding_inline_start: {xs: "0", md: "1"},
+  padding_inline_end: {xs: "0", md: "1"}
+) do %>
+  <%= render(Polaris::BaseComponent.new(**wrapper_arguments)) do %>
+    <%= render(Polaris::BaseComponent.new(**system_arguments)) do %>
+      <% tabs.each do |tab| %>
+        <%= tab %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/polaris/new_tabs_component.rb
+++ b/app/components/polaris/new_tabs_component.rb
@@ -1,0 +1,37 @@
+module Polaris
+  class NewTabsComponent < Polaris::Component
+    renders_many :tabs, Polaris::NewTabs::TabComponent
+
+    def initialize(fitted: false, wrapper_arguments: {}, **system_arguments)
+      @fitted = fitted
+      @wrapper_arguments = wrapper_arguments
+      @system_arguments = system_arguments
+    end
+
+    def wrapper_arguments
+      @wrapper_arguments.tap do |opts|
+        opts[:tag] = "div"
+        opts[:classes] = class_names(
+          @wrapper_arguments[:classes],
+          "Polaris-Tabs__Wrapper"
+        )
+      end
+    end
+
+    def system_arguments
+      @system_arguments.tap do |opts|
+        opts[:tag] = "ul"
+        opts[:role] = "tablist"
+        opts[:classes] = class_names(
+          @system_arguments[:classes],
+          "Polaris-Tabs",
+          "Polaris-Tabs--fitted": @fitted
+        )
+      end
+    end
+
+    def renders?
+      tabs.present?
+    end
+  end
+end

--- a/app/helpers/polaris/view_helper.rb
+++ b/app/helpers/polaris/view_helper.rb
@@ -74,6 +74,7 @@ module Polaris
       skeleton_thumbnail:       "Polaris::SkeletonThumbnailComponent",
       spacer:                   "Polaris::SpacerComponent",
       tabs:                     "Polaris::TabsComponent",
+      new_tabs:                 "Polaris::NewTabsComponent",
       tag:                      "Polaris::TagComponent",
       text:                     "Polaris::TextComponent",
       text_container:           "Polaris::TextContainerComponent",

--- a/demo/app/previews/new_tabs_component_preview.rb
+++ b/demo/app/previews/new_tabs_component_preview.rb
@@ -1,0 +1,13 @@
+class NewTabsComponentPreview < ViewComponent::Preview
+  def default
+  end
+
+  def inside_card
+  end
+
+  def fitted
+  end
+
+  def with_badge
+  end
+end

--- a/demo/app/previews/new_tabs_component_preview/default.html.erb
+++ b/demo/app/previews/new_tabs_component_preview/default.html.erb
@@ -1,0 +1,6 @@
+<%= polaris_new_tabs do |tabs| %>
+  <% tabs.with_tab(title: "All", active: true) %>
+  <% tabs.with_tab(title: "Accepts marketing") %>
+  <% tabs.with_tab(title: "Repeat customer") %>
+  <% tabs.with_tab(title: "Prospects", url: "#") %>
+<% end %>

--- a/demo/app/previews/new_tabs_component_preview/fitted.html.erb
+++ b/demo/app/previews/new_tabs_component_preview/fitted.html.erb
@@ -1,0 +1,12 @@
+<%= polaris_card do |card| %>
+  <% card.with_section(unstyled: true) do %>
+    <%= polaris_new_tabs(fitted: true) do |tabs| %>
+      <% tabs.with_tab(title: "All", active: true) %>
+      <% tabs.with_tab(title: "Accepts marketing") %>
+    <% end %>
+  <% end %>
+
+  <% card.with_section(title: "All") do %>
+    Tab "All" selected.
+  <% end %>
+<% end %>

--- a/demo/app/previews/new_tabs_component_preview/inside_card.html.erb
+++ b/demo/app/previews/new_tabs_component_preview/inside_card.html.erb
@@ -1,0 +1,14 @@
+<%= polaris_card do |card| %>
+  <% card.with_section(unstyled: true) do %>
+    <%= polaris_new_tabs do |tabs| %>
+      <% tabs.with_tab(title: "All", active: true) %>
+      <% tabs.with_tab(title: "Accepts marketing") %>
+      <% tabs.with_tab(title: "Repeat customer") %>
+      <% tabs.with_tab(title: "Prospects", url: "#") %>
+    <% end %>
+  <% end %>
+
+  <% card.with_section(title: "All") do %>
+    Tab "All" selected.
+  <% end %>
+<% end %>

--- a/demo/app/previews/new_tabs_component_preview/with_badge.html.erb
+++ b/demo/app/previews/new_tabs_component_preview/with_badge.html.erb
@@ -1,0 +1,16 @@
+<%= polaris_card do |card| %>
+  <% card.with_section(unstyled: true) do %>
+    <%= polaris_new_tabs(fitted: true) do |tabs| %>
+      <% tabs.with_tab(title: "All", active: true) do |tab| %>
+        <% tab.with_badge { "10+" } %>
+      <% end %>
+      <% tabs.with_tab(title: "Accepts marketing") do |tab| %>
+        <% tab.with_badge { "4" } %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <% card.with_section(title: "All") do %>
+    Tab "All" selected.
+  <% end %>
+<% end %>

--- a/test/components/polaris/new_tabs_component_test.rb
+++ b/test/components/polaris/new_tabs_component_test.rb
@@ -1,0 +1,45 @@
+require "test_helper"
+
+class NewTabsComponentTest < Minitest::Test
+  include Polaris::ComponentTestHelpers
+
+  def test_default_tabs
+    render_inline(Polaris::NewTabsComponent.new) do |tabs|
+      tabs.with_tab(title: "Active", active: true)
+      tabs.with_tab(title: "With URL", url: "https://shopify.dev")
+    end
+
+    assert_selector ".Polaris-Tabs__Wrapper > ul.Polaris-Tabs" do
+      assert_selector "li.Polaris-Tabs__TabContainer", count: 2
+      assert_selector "li:nth-of-type(1)" do
+        assert_selector "button.Polaris-Tabs__Tab.Polaris-Tabs__Tab--active" do
+          assert_selector "span", text: "Active"
+        end
+      end
+      assert_selector "li:nth-of-type(2)" do
+        assert_selector %(a.Polaris-Tabs__Tab[href="https://shopify.dev"]), text: "With URL"
+      end
+    end
+  end
+
+  def test_fitted_tabs
+    render_inline(Polaris::NewTabsComponent.new(fitted: true)) do |tabs|
+      tabs.with_tab(title: "Default")
+    end
+
+    assert_selector "ul.Polaris-Tabs.Polaris-Tabs--fitted"
+  end
+
+  def test_tabs_with_badge
+    render_inline(Polaris::NewTabsComponent.new(fitted: true)) do |tabs|
+      tabs.with_tab(title: "Default") do |tab|
+        tab.with_badge { "100" }
+      end
+    end
+
+    assert_selector ".Polaris-Tabs__Tab > .Polaris-LegacyStack" do
+      assert_text "Default"
+      assert_selector "span.Polaris-Badge", text: 100
+    end
+  end
+end


### PR DESCRIPTION
Implemented new Polaris tabs UI. To avoid breaking changes it will be using `New` prefix until next major release.

Example:
```erb
<%= polaris_new_tabs do |tabs| %>
  <% tabs.with_tab(title: "All", active: true) %>
  <% tabs.with_tab(title: "Accepts marketing") %>
  <% tabs.with_tab(title: "Repeat customer") %>
  <% tabs.with_tab(title: "Prospects", url: "#") %>
<% end %>
```