### PR TITLE
Update standalone checkbox preview to use polaris_check_box to be consistent with form helpers

### DIFF
--- a/demo/app/previews/checkbox_component_preview/default.html.erb
+++ b/demo/app/previews/checkbox_component_preview/default.html.erb
@@ -1,1 +1,1 @@
-<%= polaris_checkbox(label: "Basic checkbox") %>
+<%= polaris_check_box(label: "Basic checkbox") %>

--- a/demo/app/previews/checkbox_component_preview/indeterminate.html.erb
+++ b/demo/app/previews/checkbox_component_preview/indeterminate.html.erb
@@ -1,1 +1,1 @@
-<%= polaris_checkbox(label: "Indeterminate checkbox", checked: :indeterminate) %>
+<%= polaris_check_box(label: "Indeterminate checkbox", checked: :indeterminate) %>

--- a/demo/app/previews/checkbox_component_preview/with_error.html.erb
+++ b/demo/app/previews/checkbox_component_preview/with_error.html.erb
@@ -1,1 +1,1 @@
-<%= polaris_checkbox(label: "Basic checkbox", error: "Invalid value") %>
+<%= polaris_check_box(label: "Basic checkbox", error: "Invalid value") %>

--- a/demo/app/previews/checkbox_component_preview/with_help_text.html.erb
+++ b/demo/app/previews/checkbox_component_preview/with_help_text.html.erb
@@ -1,4 +1,4 @@
-<%= polaris_checkbox(
+<%= polaris_check_box(
   label: "Basic checkbox",
   checked: true,
   help_text: "Customers must review their order details before purchasing.",


### PR DESCRIPTION
Small thing, but I often start with the standalone helpers when building out UI and the naming difference between these tends to trip me up when I end up wrapping it in a form.