### PR TITLE
Support icon-only text field label action

### DIFF
--- a/app/components/polaris/labelled_component.rb
+++ b/app/components/polaris/labelled_component.rb
@@ -21,9 +21,13 @@ module Polaris
       @help_text = help_text
       @error = error
 
-      if label_action && label_action[:content].present?
-        label_content = label_action.delete(:content)
-        with_label_action(**label_action) { label_content }
+      if label_action
+        if label_action[:content].present?
+          label_content = label_action.delete(:content)
+          with_label_action(**label_action) { label_content }
+        elsif label_action[:icon_name].present?
+          with_label_action(**label_action)
+        end
       end
 
       @system_arguments = system_arguments

--- a/demo/app/previews/button_component_preview/icon_only.html.erb
+++ b/demo/app/previews/button_component_preview/icon_only.html.erb
@@ -5,3 +5,5 @@
 <%= polaris_button_to(Product.new) do |button| %>
   <% button.with_icon(name: "ArrowRightIcon") %>
 <% end %>
+
+<%= polaris_button(icon_name: "PlusCircleIcon") %>

--- a/demo/app/previews/text_field_component_preview/with_label_action.html.erb
+++ b/demo/app/previews/text_field_component_preview/with_label_action.html.erb
@@ -1,6 +1,22 @@
-<%= polaris_text_field(
-  name: :tariff_code,
-  value: "6201.11.0000",
-  label: "Tariff code",
-  label_action: { url: "#", content: "Look up codes" },
-) %>
+<%= polaris_text_container do %>
+  <%= polaris_text_field(
+    name: :tariff_code,
+    value: "6201.11.0000",
+    label: "Tariff code",
+    label_action: { url: "#", content: "Look up codes" },
+  ) %>
+
+  <%= polaris_text_field(
+    name: :tariff_code,
+    value: "6201.11.0000",
+    label: "Tariff code",
+    label_action: { url: "#", content: "Add", icon_name: "PlusCircleIcon" },
+  ) %>
+
+  <%= polaris_text_field(
+    name: :tariff_code,
+    value: "6201.11.0000",
+    label: "Tariff code",
+    label_action: { url: "#", icon_name: "PlusCircleIcon" },
+  ) %>
+<% end %>


### PR DESCRIPTION
Example:
```erb
<%= polaris_text_field(
  name: :tariff_code,
  value: "6201.11.0000",
  label: "Tariff code",
  label_action: { url: "#", icon_name: "PlusCircleIcon" },
) %>
```

![CleanShot 2025-05-15 at 08 18 14@2x](https://github.com/user-attachments/assets/1dc521e6-bd27-4568-9cb0-e64308867c44)
