### PR TITLE
Add clear_errors_on_focus for Select component

### DIFF
--- a/app/assets/javascripts/polaris_view_components.js
+++ b/app/assets/javascripts/polaris_view_components.js
@@ -2276,6 +2276,17 @@ class Select extends Controller {
     const option = this.selectTarget.options[this.selectTarget.selectedIndex];
     this.selectedOptionTarget.innerText = option.text;
   }
+  clearErrorMessages() {
+    const polarisSelect = this.selectTarget.closest(".Polaris-Select");
+    const wrapper = polarisSelect.parentElement;
+    const inlineError = wrapper.querySelector(".Polaris-InlineError");
+    if (polarisSelect) {
+      polarisSelect.classList.remove("Polaris-Select--error");
+    }
+    if (inlineError) {
+      inlineError.remove();
+    }
+  }
 }
 
 class TextField extends Controller {

--- a/app/assets/javascripts/polaris_view_components/select_controller.js
+++ b/app/assets/javascripts/polaris_view_components/select_controller.js
@@ -11,4 +11,17 @@ export default class extends Controller {
     const option = this.selectTarget.options[this.selectTarget.selectedIndex]
     this.selectedOptionTarget.innerText = option.text
   }
+
+  clearErrorMessages() {
+    const polarisSelect = this.selectTarget.closest(".Polaris-Select")
+    const wrapper = polarisSelect.parentElement
+    const inlineError = wrapper.querySelector(".Polaris-InlineError")
+
+    if (polarisSelect) {
+      polarisSelect.classList.remove("Polaris-Select--error")
+    }
+    if (inlineError) {
+      inlineError.remove()
+    }
+  }
 }

--- a/app/components/polaris/select_component.rb
+++ b/app/components/polaris/select_component.rb
@@ -21,6 +21,7 @@ module Polaris
       help_text: nil,
       error: false,
       grouped: false,
+      clear_errors_on_focus: false,
       wrapper_arguments: {},
       select_options: {},
       input_options: {},
@@ -69,6 +70,7 @@ module Polaris
         error: error
       }.merge(wrapper_arguments)
 
+      @clear_errors_on_focus = clear_errors_on_focus
       @select_options = select_options
 
       @input_options = input_options
@@ -77,6 +79,9 @@ module Polaris
       @input_options[:disabled] = disabled
       @input_options[:data] ||= {}
       prepend_option(@input_options[:data], :polaris_select_target, "select")
+      if @clear_errors_on_focus
+        prepend_option(@input_options[:data], :action, "click->polaris-select#clearErrorMessages")
+      end
       prepend_option(@input_options[:data], :action, "polaris-select#update")
     end
 

--- a/demo/app/previews/select_component_preview.rb
+++ b/demo/app/previews/select_component_preview.rb
@@ -28,4 +28,7 @@ class SelectComponentPreview < ViewComponent::Preview
 
   def with_inline_error
   end
+
+  def clear_error_on_focus
+  end
 end

--- a/demo/app/previews/select_component_preview/clear_error_on_focus.html.erb
+++ b/demo/app/previews/select_component_preview/clear_error_on_focus.html.erb
@@ -1,0 +1,12 @@
+<%= polaris_select(
+  name: :date_range,
+  label: "Date range",
+  options: {
+    "Today" => "today",
+    "Yesterday" => "yesterday",
+    "Last 7 days" => "lastWeek",
+  },
+  selected: "yesterday",
+  error: "Incorrect date range",
+  clear_errors_on_focus: true
+) %>

--- a/test/components/polaris/select_component_test.rb
+++ b/test/components/polaris/select_component_test.rb
@@ -344,4 +344,27 @@ class SelectComponentTest < Minitest::Test
       end
     end
   end
+
+  def test_clear_errors_on_focus
+    render_inline(Polaris::SelectComponent.new(
+      name: :input_name,
+      label: "Input Label",
+      options: {"Option 1" => "option1", "Option 2" => "option2"},
+      selected: "option2",
+      clear_errors_on_focus: true
+    ))
+
+    assert_selector "select[name=input_name][data-action~='click->polaris-select#clearErrorMessages']"
+
+    render_inline(Polaris::SelectComponent.new(
+      name: :input_name,
+      label: "Input Label",
+      options: {"Option 1" => "option1", "Option 2" => "option2"},
+      selected: "option2",
+      clear_errors_on_focus: true,
+      input_options: {data: {action: "custom#action"}}
+    ))
+
+    assert_selector "select[name=input_name][data-action~='click->polaris-select#clearErrorMessages']"
+  end
 end


### PR DESCRIPTION
Example:
```erb
<%= polaris_select(
  name: :date_range,
  label: "Date range",
  options: {
    "Today" => "today",
    "Yesterday" => "yesterday",
    "Last 7 days" => "lastWeek",
  },
  selected: "yesterday",
  error: "Incorrect date range",
  clear_errors_on_focus: true
) %>
```

Demo:

https://github.com/user-attachments/assets/dc05aede-368b-4111-85f7-f89ddedd8f33
