### PR TITLE
Disable form builder field errors when false is passed to error option

### DIFF
--- a/app/helpers/polaris/form_builder.rb
+++ b/app/helpers/polaris/form_builder.rb
@@ -50,18 +50,14 @@ module Polaris
     end
 
     def polaris_text_field(method, **options, &block)
-      options[:error] ||= error_for(method)
-      if options[:error_hidden] && options[:error]
-        options[:error] = !!options[:error]
-      end
+      apply_error_options(options, method)
+
       render Polaris::TextFieldComponent.new(form: self, attribute: method, **options), &block
     end
 
     def polaris_select(method, **options, &block)
-      options[:error] ||= error_for(method)
-      if options[:error_hidden] && options[:error]
-        options[:error] = !!options[:error]
-      end
+      apply_error_options(options, method)
+
       value = object&.public_send(method)
       if value.present?
         options[:selected] = value
@@ -70,34 +66,25 @@ module Polaris
     end
 
     def polaris_check_box(method, **options, &block)
-      options[:error] ||= error_for(method)
-      if options[:error_hidden] && options[:error]
-        options[:error] = !!options[:error]
-      end
+      apply_error_options(options, method)
+
       render Polaris::CheckboxComponent.new(form: self, attribute: method, **options, &block)
     end
 
     def polaris_radio_button(method, **options, &block)
-      options[:error] ||= error_for(method)
-      if options[:error_hidden] && options[:error]
-        options[:error] = !!options[:error]
-      end
+      apply_error_options(options, method)
+
       render Polaris::RadioButtonComponent.new(form: self, attribute: method, **options, &block)
     end
 
     def polaris_dropzone(method, **options, &block)
-      options[:error] ||= error_for(method)
-      if options[:error_hidden] && options[:error]
-        options[:error] = !!options[:error]
-      end
+      apply_error_options(options, method)
+
       render Polaris::DropzoneComponent.new(form: self, attribute: method, **options, &block)
     end
 
     def polaris_collection_check_boxes(method, collection, value_method, text_method, **options, &block)
-      options[:error] ||= error_for(method)
-      if options[:error_hidden] && options[:error]
-        options[:error] = !!options[:error]
-      end
+      apply_error_options(options, method)
 
       value = object&.public_send(method)
       if value.present?
@@ -124,11 +111,19 @@ module Polaris
     end
 
     def polaris_autocomplete(method, **options, &block)
-      options[:error] ||= error_for(method)
+      apply_error_options(options, method)
+
+      render Polaris::AutocompleteComponent.new(form: self, attribute: method, name: method, **options), &block
+    end
+
+    private
+
+    def apply_error_options(options, method)
+      options[:error] ||= error_for(method) unless options.has_key?(:error)
+
       if options[:error_hidden] && options[:error]
         options[:error] = !!options[:error]
       end
-      render Polaris::AutocompleteComponent.new(form: self, attribute: method, name: method, **options), &block
     end
   end
 end

--- a/test/helpers/polaris/form_builder_test.rb
+++ b/test/helpers/polaris/form_builder_test.rb
@@ -58,6 +58,55 @@ class Polaris::ViewHelperTest < ActionView::TestCase
     end
   end
 
+  test "#polaris_text_field with error" do
+    @product.errors.add(:title, "Error")
+    @rendered_content = @builder.polaris_text_field(:title)
+
+    assert_selector ".Polaris-Label" do
+      assert_selector "label", text: "Title"
+    end
+    assert_selector ".Polaris-TextField" do
+      assert_selector %(input[name="product[title]"])
+
+      assert_selector ".Polaris-Labelled__Error" do
+        assert_selector ".Polaris-InlineError" do
+          assert_selector ".Polaris-InlineError__Icon"
+          assert_text "Title Error"
+        end
+      end
+    end
+  end
+
+  test "#polaris_text_field with error can be hidden" do
+    @product.errors.add(:title, "Error")
+    @rendered_content = @builder.polaris_text_field(:title, error_hidden: true)
+
+    assert_selector ".Polaris-Label" do
+      assert_selector "label", text: "Title"
+    end
+    assert_selector ".Polaris-TextField.Polaris-TextField--error" do
+      assert_selector %(input[name="product[title]"])
+
+      assert_no_selector ".Polaris-Labelled__Error"
+    end
+  end
+
+  test "#polaris_text_field with error can be removed" do
+    @product.errors.add(:title, "Error")
+    @rendered_content = @builder.polaris_text_field(:title, error: false)
+
+    assert_selector ".Polaris-Label" do
+      assert_selector "label", text: "Title"
+    end
+
+    assert_selector ".Polaris-TextField" do
+      assert_selector %(input[name="product[title]"])
+      assert_no_selector ".Polaris-Labelled__Error"
+    end
+
+    assert_no_selector ".Polaris-TextField.Polaris-TextField--error"
+  end
+
   test "#polaris_text_field_with_block" do
     @rendered_content = @builder.polaris_text_field(:title, help_text: "Help Text") do |c|
       c.with_connected_right do


### PR DESCRIPTION
Previously there was no way to disable the inline error on form fields when using the builder, this change fixes that.

There is already a `error_hidden` option but that only hides the error message, not the error styling.

The reason I want this is I have a multi select checkbox field so the checkbox is rendered multiple times with the same name/method and the error shows up for all of them, I want to disable that and display the error in the section instead.

If you would like additional tests or any other changes just let me know!