### PR TITLE
Performance optimizations on large DataTables

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+tabWidth: 2
+semi: false
+singleQuote: false
+arrowParens: avoid
+printWidth: 120

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,0 @@
-tabWidth: 2
-semi: false
-singleQuote: false
-arrowParens: avoid
-printWidth: 120

--- a/app/assets/javascripts/polaris_view_components.js
+++ b/app/assets/javascripts/polaris_view_components.js
@@ -357,30 +357,39 @@ class Collapsible extends Controller {
 }
 
 class DataTable extends Controller {
-  static targets=[ "row" ];
   connect() {
-    this.rowTargets.forEach((row => {
-      row.addEventListener("mouseover", (() => this.handleHover(row)));
-      row.addEventListener("mouseout", (() => this.handleLeave(row)));
-    }));
+    this.handleMouseOver = this.handleMouseOver.bind(this);
+    this.handleMouseOut = this.handleMouseOut.bind(this);
+    this.element.addEventListener("mouseover", this.handleMouseOver);
+    this.element.addEventListener("mouseout", this.handleMouseOut);
   }
   disconnect() {
-    this.rowTargets.forEach((row => {
-      row.removeEventListener("mouseover", (() => this.handleHover(row)));
-      row.removeEventListener("mouseout", (() => this.handleLeave(row)));
-    }));
+    this.element.removeEventListener("mouseover", this.handleMouseOver);
+    this.element.removeEventListener("mouseout", this.handleMouseOut);
   }
-  handleHover(row) {
-    const cells = row.querySelectorAll(".Polaris-DataTable__Cell");
-    cells.forEach((cell => {
-      cell.classList.add("Polaris-DataTable__Cell--hovered");
-    }));
+  handleMouseOver(event) {
+    const row = event.target.closest(".Polaris-DataTable--hoverable");
+    if (row && row !== this.hoveredRow) {
+      this.clearHoveredRow();
+      this.hoveredRow = row;
+      row.querySelectorAll(".Polaris-DataTable__Cell").forEach((cell => {
+        cell.classList.add("Polaris-DataTable__Cell--hovered");
+      }));
+    }
   }
-  handleLeave(row) {
-    const cells = row.querySelectorAll(".Polaris-DataTable__Cell");
-    cells.forEach((cell => {
-      cell.classList.remove("Polaris-DataTable__Cell--hovered");
-    }));
+  handleMouseOut(event) {
+    const row = event.target.closest(".Polaris-DataTable--hoverable");
+    if (row && !row.contains(event.relatedTarget)) {
+      this.clearHoveredRow();
+    }
+  }
+  clearHoveredRow() {
+    if (this.hoveredRow) {
+      this.hoveredRow.querySelectorAll(".Polaris-DataTable__Cell").forEach((cell => {
+        cell.classList.remove("Polaris-DataTable__Cell--hovered");
+      }));
+      this.hoveredRow = null;
+    }
   }
 }
 

--- a/app/assets/javascripts/polaris_view_components.js
+++ b/app/assets/javascripts/polaris_view_components.js
@@ -358,8 +358,8 @@ class Collapsible extends Controller {
 
 class DataTable extends Controller {
   connect() {
-    this.handleMouseOver = this.handleMouseOver.bind(this);
-    this.handleMouseOut = this.handleMouseOut.bind(this);
+    this.handleMouseOver = debounce(this.handleMouseOver.bind(this), 50);
+    this.handleMouseOut = debounce(this.handleMouseOut.bind(this), 50);
     this.element.addEventListener("mouseover", this.handleMouseOver);
     this.element.addEventListener("mouseout", this.handleMouseOut);
   }

--- a/app/assets/javascripts/polaris_view_components/data_table_controller.js
+++ b/app/assets/javascripts/polaris_view_components/data_table_controller.js
@@ -1,33 +1,43 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["row"]
-
   connect() {
-    this.rowTargets.forEach(row => {
-      row.addEventListener("mouseover", () => this.handleHover(row))
-      row.addEventListener("mouseout", () => this.handleLeave(row))
-    })
+    this.handleMouseOver = this.handleMouseOver.bind(this)
+    this.handleMouseOut = this.handleMouseOut.bind(this)
+
+    this.element.addEventListener("mouseover", this.handleMouseOver)
+    this.element.addEventListener("mouseout", this.handleMouseOut)
   }
 
   disconnect() {
-    this.rowTargets.forEach(row => {
-      row.removeEventListener("mouseover", () => this.handleHover(row))
-      row.removeEventListener("mouseout", () => this.handleLeave(row))
-    })
+    this.element.removeEventListener("mouseover", this.handleMouseOver)
+    this.element.removeEventListener("mouseout", this.handleMouseOut)
   }
 
-  handleHover(row) {
-    const cells = row.querySelectorAll(".Polaris-DataTable__Cell")
-    cells.forEach(cell => {
-      cell.classList.add("Polaris-DataTable__Cell--hovered")
-    })
+  handleMouseOver(event) {
+    const row = event.target.closest(".Polaris-DataTable--hoverable")
+    if (row && row !== this.hoveredRow) {
+      this.clearHoveredRow()
+      this.hoveredRow = row
+      row.querySelectorAll(".Polaris-DataTable__Cell").forEach(cell => {
+        cell.classList.add("Polaris-DataTable__Cell--hovered")
+      })
+    }
   }
 
-  handleLeave(row) {
-    const cells = row.querySelectorAll(".Polaris-DataTable__Cell")
-    cells.forEach(cell => {
-      cell.classList.remove("Polaris-DataTable__Cell--hovered")
-    })
+  handleMouseOut(event) {
+    const row = event.target.closest(".Polaris-DataTable--hoverable")
+    if (row && !row.contains(event.relatedTarget)) {
+      this.clearHoveredRow()
+    }
+  }
+
+  clearHoveredRow() {
+    if (this.hoveredRow) {
+      this.hoveredRow.querySelectorAll(".Polaris-DataTable__Cell").forEach(cell => {
+        cell.classList.remove("Polaris-DataTable__Cell--hovered")
+      })
+      this.hoveredRow = null
+    }
   }
 }

--- a/app/assets/javascripts/polaris_view_components/data_table_controller.js
+++ b/app/assets/javascripts/polaris_view_components/data_table_controller.js
@@ -1,9 +1,10 @@
 import { Controller } from "@hotwired/stimulus"
+import { debounce } from "./utils"
 
 export default class extends Controller {
   connect() {
-    this.handleMouseOver = this.handleMouseOver.bind(this)
-    this.handleMouseOut = this.handleMouseOut.bind(this)
+    this.handleMouseOver = debounce(this.handleMouseOver.bind(this), 50)
+    this.handleMouseOut = debounce(this.handleMouseOut.bind(this), 50)
 
     this.element.addEventListener("mouseover", this.handleMouseOver)
     this.element.addEventListener("mouseout", this.handleMouseOut)

--- a/app/assets/stylesheets/polaris_view_components.css
+++ b/app/assets/stylesheets/polaris_view_components.css
@@ -537,11 +537,14 @@
     width: 100%;
   }/* Select *//* Fix for Safari bug: https://github.com/baoagency/polaris_view_components/issues/454 */select.Polaris-Select__Input {
   font-weight: 400;
-}html[class~="Polaris-Summer-Editions-2023"] .Polaris-DataTable .Polaris-DataTable__Cell:not(.Polaris-DataTable__Cell--flush):first-child,
-  html[class~="Polaris-Summer-Editions-2023"] .Polaris-DataTable .Polaris-DataTable__Heading:not(.Polaris-DataTable__Heading--flush):first-child {
+}html[class~='Polaris-Summer-Editions-2023'] .Polaris-DataTable .Polaris-DataTable__ScrollContainer {
+    content-visibility: auto;
+    contain-intrinsic-size: auto 1000px;
+  }html[class~='Polaris-Summer-Editions-2023'] .Polaris-DataTable .Polaris-DataTable__Cell:not(.Polaris-DataTable__Cell--flush):first-child,
+  html[class~='Polaris-Summer-Editions-2023'] .Polaris-DataTable .Polaris-DataTable__Heading:not(.Polaris-DataTable__Heading--flush):first-child {
     padding-left: var(--p-space-400);
-  }html[class~="Polaris-Summer-Editions-2023"] .Polaris-DataTable .Polaris-DataTable__Cell:not(.Polaris-DataTable__Cell--flush):last-child,
-  html[class~="Polaris-Summer-Editions-2023"] .Polaris-DataTable .Polaris-DataTable__Heading:not(.Polaris-DataTable__Heading--flush):last-child {
+  }html[class~='Polaris-Summer-Editions-2023'] .Polaris-DataTable .Polaris-DataTable__Cell:not(.Polaris-DataTable__Cell--flush):last-child,
+  html[class~='Polaris-Summer-Editions-2023'] .Polaris-DataTable .Polaris-DataTable__Heading:not(.Polaris-DataTable__Heading--flush):last-child {
     padding-right: var(--p-space-400);
   }html[class~="Polaris-Summer-Editions-2023"] .Polaris-FooterHelp .Polaris-FooterHelp__Text {
     font-size: var(--p-font-size-325);

--- a/app/assets/stylesheets/polaris_view_components.css
+++ b/app/assets/stylesheets/polaris_view_components.css
@@ -537,14 +537,18 @@
     width: 100%;
   }/* Select *//* Fix for Safari bug: https://github.com/baoagency/polaris_view_components/issues/454 */select.Polaris-Select__Input {
   font-weight: 400;
-}html[class~='Polaris-Summer-Editions-2023'] .Polaris-DataTable .Polaris-DataTable__ScrollContainer {
+}html[class~="Polaris-Summer-Editions-2023"] .Polaris-DataTable .Polaris-DataTable__TableRow {
     content-visibility: auto;
-    contain-intrinsic-size: auto 1000px;
-  }html[class~='Polaris-Summer-Editions-2023'] .Polaris-DataTable .Polaris-DataTable__Cell:not(.Polaris-DataTable__Cell--flush):first-child,
-  html[class~='Polaris-Summer-Editions-2023'] .Polaris-DataTable .Polaris-DataTable__Heading:not(.Polaris-DataTable__Heading--flush):first-child {
+    contain-intrinsic-size: auto 250px;
+  }html[class~="Polaris-Summer-Editions-2023"] .Polaris-DataTable .Polaris-DataTable__Cell:not(.Polaris-DataTable__Cell--flush):first-child,
+  html[class~="Polaris-Summer-Editions-2023"] .Polaris-DataTable .Polaris-DataTable__Heading:not(
+      .Polaris-DataTable__Heading--flush
+    ):first-child {
     padding-left: var(--p-space-400);
-  }html[class~='Polaris-Summer-Editions-2023'] .Polaris-DataTable .Polaris-DataTable__Cell:not(.Polaris-DataTable__Cell--flush):last-child,
-  html[class~='Polaris-Summer-Editions-2023'] .Polaris-DataTable .Polaris-DataTable__Heading:not(.Polaris-DataTable__Heading--flush):last-child {
+  }html[class~="Polaris-Summer-Editions-2023"] .Polaris-DataTable .Polaris-DataTable__Cell:not(.Polaris-DataTable__Cell--flush):last-child,
+  html[class~="Polaris-Summer-Editions-2023"] .Polaris-DataTable .Polaris-DataTable__Heading:not(
+      .Polaris-DataTable__Heading--flush
+    ):last-child {
     padding-right: var(--p-space-400);
   }html[class~="Polaris-Summer-Editions-2023"] .Polaris-FooterHelp .Polaris-FooterHelp__Text {
     font-size: var(--p-font-size-325);

--- a/app/assets/stylesheets/polaris_view_components/data_table.pcss
+++ b/app/assets/stylesheets/polaris_view_components/data_table.pcss
@@ -1,15 +1,19 @@
-html[class~='Polaris-Summer-Editions-2023'] .Polaris-DataTable {
-  .Polaris-DataTable__ScrollContainer {
+html[class~="Polaris-Summer-Editions-2023"] .Polaris-DataTable {
+  .Polaris-DataTable__TableRow {
     content-visibility: auto;
-    contain-intrinsic-size: auto 1000px;
+    contain-intrinsic-size: auto 250px;
   }
   .Polaris-DataTable__Cell:not(.Polaris-DataTable__Cell--flush):first-child,
-  .Polaris-DataTable__Heading:not(.Polaris-DataTable__Heading--flush):first-child {
+  .Polaris-DataTable__Heading:not(
+      .Polaris-DataTable__Heading--flush
+    ):first-child {
     padding-left: var(--p-space-400);
   }
 
   .Polaris-DataTable__Cell:not(.Polaris-DataTable__Cell--flush):last-child,
-  .Polaris-DataTable__Heading:not(.Polaris-DataTable__Heading--flush):last-child {
+  .Polaris-DataTable__Heading:not(
+      .Polaris-DataTable__Heading--flush
+    ):last-child {
     padding-right: var(--p-space-400);
   }
 }

--- a/app/assets/stylesheets/polaris_view_components/data_table.pcss
+++ b/app/assets/stylesheets/polaris_view_components/data_table.pcss
@@ -1,5 +1,8 @@
-html[class~="Polaris-Summer-Editions-2023"] .Polaris-DataTable {
-
+html[class~='Polaris-Summer-Editions-2023'] .Polaris-DataTable {
+  .Polaris-DataTable__ScrollContainer {
+    content-visibility: auto;
+    contain-intrinsic-size: auto 1000px;
+  }
   .Polaris-DataTable__Cell:not(.Polaris-DataTable__Cell--flush):first-child,
   .Polaris-DataTable__Heading:not(.Polaris-DataTable__Heading--flush):first-child {
     padding-left: var(--p-space-400);

--- a/app/components/polaris/data_table_component.rb
+++ b/app/components/polaris/data_table_component.rb
@@ -56,7 +56,6 @@ module Polaris
         )
         args[:id] = dom_id(row) if row.respond_to?(:to_key)
         args[:data] ||= {}
-        args[:data][:polaris_data_table_target] = "row"
       end
     end
 


### PR DESCRIPTION
**Javascript optimizations:**
- 2 event listeners total, instead of 2×n (I have tables with 500 rows, meaning 1000 event listeners 😁)
- Tracks `hoveredRow` - avoids re-querying cells when moving within the same row
- Proper cleanup - bound functions can actually be removed
- `relatedTarget` check - only clears when truly leaving the row

**CSS optimizations:**

- Adds CSS [content-visibility](https://web.dev/articles/content-visibility) to table scroll container. The [content-visibility](https://drafts.csswg.org/css-contain/#propdef-content-visibility) property enables the user agent to skip an element's rendering work, including layout and painting, until it is needed. Because rendering is skipped, if a large portion of your content is off-screen, using the content-visibility property makes the initial user load much faster. It also allows for faster interactions with the on-screen content.