### PR TITLE
Added params to the button lookbook preview

### DIFF
--- a/demo/app/previews/button_component_preview.rb
+++ b/demo/app/previews/button_component_preview.rb
@@ -73,4 +73,71 @@ class ButtonComponentPreview < ViewComponent::Preview
 
   def with_tooltip
   end
+
+  # @label Playground
+  # @param button_label text "Button label"
+  # @param url url "Button URL"
+  # @param icon_name text "Polaris icon name"
+  # @param tooltip text "Tooltip text"
+  # @param size select "Button size" {{Polaris::HeadlessButton::SIZE_OPTIONS}}
+  # @param text_align select "Text alignment" {{Polaris::HeadlessButton::TEXT_ALIGN_OPTIONS}}
+  # @param disclosure select "Disclosure icon" {{Polaris::HeadlessButton::DISCLOSURE_OPTIONS}}
+  # @param primary toggle "Primary style"
+  # @param destructive toggle "Destructive style"
+  # @param plain toggle "Plain style"
+  # @param outline toggle "Outline style"
+  # @param monochrome toggle "Monochrome style"
+  # @param pressed toggle "Pressed state"
+  # @param full_width toggle "Full width"
+  # @param external toggle "Open in new tab"
+  # @param submit toggle "Submit button type"
+  # @param disabled toggle "Disable the button"
+  # @param loading toggle "Show loading spinner"
+  # @param disable_with_loader toggle "Disable on click with loader"
+  # @param remove_underline toggle "Remove underline (plain + monochrome)"
+  def playground(
+    button_label: "Add product",
+    url: "https://shopify.com",
+    icon_name: "PlusCircleIcon",
+    tooltip: "Add product",
+    size: Polaris::HeadlessButton::SIZE_DEFAULT,
+    text_align: Polaris::HeadlessButton::TEXT_ALIGN_DEFAULT,
+    disclosure: Polaris::HeadlessButton::DISCLOSURE_DEFAULT,
+    primary: false,
+    destructive: false,
+    plain: false,
+    outline: false,
+    monochrome: false,
+    pressed: false,
+    full_width: false,
+    external: false,
+    submit: false,
+    disabled: false,
+    loading: false,
+    disable_with_loader: false,
+    remove_underline: false
+  )
+    render_with_template(locals: {
+      button_label: button_label,
+      url: url,
+      icon_name: icon_name,
+      tooltip: tooltip,
+      size: size,
+      text_align: text_align,
+      disclosure: disclosure,
+      primary: primary,
+      destructive: destructive,
+      plain: plain,
+      outline: outline,
+      monochrome: monochrome,
+      pressed: pressed,
+      full_width: full_width,
+      external: external,
+      submit: submit,
+      disabled: disabled,
+      loading: loading,
+      disable_with_loader: disable_with_loader,
+      remove_underline: remove_underline,
+    })
+  end
 end

--- a/demo/app/previews/button_component_preview/playground.html.erb
+++ b/demo/app/previews/button_component_preview/playground.html.erb
@@ -1,0 +1,21 @@
+<%= polaris_button(
+  url: url,
+  icon_name: icon_name,
+  tooltip: tooltip,
+  size: size,
+  text_align: text_align,
+  disclosure: disclosure,
+  primary: primary,
+  destructive: destructive,
+  plain: plain,
+  outline: outline,
+  monochrome: monochrome,
+  pressed: pressed,
+  full_width: full_width,
+  external: external,
+  submit: submit,
+  disabled: disabled,
+  loading: loading,
+  disable_with_loader: disable_with_loader,
+  remove_underline: remove_underline
+) { button_label } %>


### PR DESCRIPTION
Related to #180 

## Add interactive playground to ButtonComponent preview                                                                       
                                                                                                                                 
Adds a `playground` preview method to `ButtonComponentPreview` that allows developers to interactively explore all `ButtonComponent` options from the Lookbook UI.                                                                                
                                                                                                                                 
### Changes     
- Added `playground` method to `ButtonComponentPreview` with `@param` annotations for all supported button options (label, URL, icon, tooltip, size, alignment, disclosure, and all boolean toggles)
- Added `playground.html.erb` template that renders a fully configured `polaris_button` using all the exposed parameters

### Why
The existing previews each demonstrate a single feature in isolation. The playground gives developers a single interactive surface to combine any set of options and see the result live, which is useful for testing and exploration during development.