### PR TITLE
Fix form builder crash on Rails 7.2+

### DIFF
--- a/app/helpers/polaris/form_builder.rb
+++ b/app/helpers/polaris/form_builder.rb
@@ -58,7 +58,7 @@ module Polaris
     def polaris_select(method, **options, &block)
       apply_error_options(options, method)
 
-      value = object&.public_send(method)
+      value = object.public_send(method) if object.respond_to?(method)
       if value.present?
         options[:selected] = value
       end
@@ -86,7 +86,7 @@ module Polaris
     def polaris_collection_check_boxes(method, collection, value_method, text_method, **options, &block)
       apply_error_options(options, method)
 
-      value = object&.public_send(method)
+      value = object.public_send(method) if object.respond_to?(method)
       if value.present?
         options[:selected] = value.map { |el| el.public_send(value_method) }
       end

--- a/test/helpers/polaris/form_builder_test.rb
+++ b/test/helpers/polaris/form_builder_test.rb
@@ -140,6 +140,19 @@ class Polaris::ViewHelperTest < ActionView::TestCase
     end
   end
 
+  # Rails 7.2 changed `form_with` to default `model:` from `nil` to `false`,
+  # so `form_with(scope: :foo)` with no model now exposes `object` as `false`.
+  test "#polaris_select when object is false (form_with without a model on Rails 7.2+)" do
+    builder = Polaris::FormBuilder.new(:time_travel, false, self, {})
+
+    @rendered_content = builder.polaris_select(:advance_seconds, options: {"1 minute" => 60})
+
+    assert_selector ".Polaris-Select" do
+      assert_selector %(select[name="time_travel[advance_seconds]"])
+      assert_selector "option[value='60']"
+    end
+  end
+
   test "#polaris_check_box" do
     @rendered_content = @builder.polaris_check_box(:accept, label: "Checkbox Label")
 
@@ -238,6 +251,21 @@ class Polaris::ViewHelperTest < ActionView::TestCase
         assert_no_selector "input[type=checkbox][name='product[selected_markets][]'][value=2][checked='checked']"
         assert_text "Spain"
       end
+    end
+  end
+
+  # Rails 7.2 changed `form_with` to default `model:` from `nil` to `false`,
+  # so `form_with(scope: :foo)` with no model now exposes `object` as `false`.
+  test "#polaris_collection_check_boxes when object is false (form_with without a model on Rails 7.2+)" do
+    builder = Polaris::FormBuilder.new(:filters, false, self, {})
+
+    @rendered_content = builder.polaris_collection_check_boxes(:selected_markets, @available_markets, :id, :name)
+
+    assert_selector "legend", text: "Selected markets"
+    assert_selector "ul" do
+      assert_selector "li", count: 2
+      assert_selector "input[type=checkbox][name='filters[selected_markets][]'][value=1]"
+      assert_selector "input[type=checkbox][name='filters[selected_markets][]'][value=2]"
     end
   end
 


### PR DESCRIPTION
Rails 7.2 changed default model on `form_with` (from nil to false), so a `form_with(scope: :foo)` with no model now exposes object as false on the FormBuilder instead of nil.

`polaris_select` and `polaris_collection_check_boxes` uses `object&.public_send`, which only short-circuits on nil and therefore raises `NoMethodError` (false has no attribute readers) for any form scoped without a model.

This commit:

- Replace the safe-navigation call with a `respond_to?` guard so nil, false, and objects missing the attribute all short-circuit and the components render normally
- Add regression tests covering both helpers when object is false

References:
- https://github.com/rails/rails/pull/49943
